### PR TITLE
Add Gradle cache to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -30,7 +30,17 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ hashFiles('**/*.gradle*') }}-
+            gradle-
 
       # Grant execute permission for gradlew
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
This commit adds caching for Gradle dependencies and wrapper to the GitHub Actions workflow. This will speed up future builds by reusing downloaded dependencies and Gradle wrapper distributions.