### PR TITLE
Append commit hash to version name for debug builds

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
+// https://docs.gradle.org/8.2/userguide/configuration_cache.html#config_cache:requirements:external_processes
+val commitHash = providers.exec {
+    commandLine("git", "rev-parse", "--short", "HEAD")
+}.standardOutput.asText.get().trim()
+
 android {
     namespace = "dev.keiji.deviceintegrity"
     compileSdk = 36
@@ -25,6 +30,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+        }
+        debug {
+            versionNameSuffix = "-$commitHash"
         }
     }
     compileOptions {


### PR DESCRIPTION
This change modifies the build process to include the short Git commit hash in the versionName for debug builds. This will help in identifying the exact version of the debug app.