### PR TITLE
Update build_check.yml to only run on Android changes

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -6,8 +6,14 @@ name: Android Build Check
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'android/**'
+      - '.github/workflows/build_check.yml' # To ensure changes to the workflow itself are checked
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'android/**'
+      - '.github/workflows/build_check.yml' # To ensure changes to the workflow itself are checked
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This change updates the GitHub Actions workflow to only trigger builds
when changes are made within the 'android/' directory or to the workflow
file itself. This prevents unnecessary builds for changes unrelated to
the Android application, such as modifications to Markdown files.