### PR TITLE
Refactor: Rename GoogleIntegrityTokenProvider to GooglePlayIntegrityTokenProvider

### DIFF
--- a/android/app/src/main/java/com/sample/android/trivialdrivesample/di/AppIntegrityModule.kt
+++ b/android/app/src/main/java/com/sample/android/trivialdrivesample/di/AppIntegrityModule.kt
@@ -1,0 +1,20 @@
+package com.sample.android.trivialdrivesample.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dev.keiji.deviceintegrity.provider.contract.GooglePlayIntegrityTokenProvider
+import dev.keiji.deviceintegrity.provider.impl.di.GooglePlayIntegrityTokenProviderModule
+import javax.inject.Singleton
+
+@Module(includes = [GooglePlayIntegrityTokenProviderModule::class])
+@InstallIn(SingletonComponent::class)
+object AppIntegrityModule {
+
+    // This module doesn't need to provide GooglePlayIntegrityTokenProvider directly
+    // if GooglePlayIntegrityTokenProviderModule is included and already provides it.
+    // Hilt will find the provider from the included module.
+}

--- a/android/provider/contract/src/main/java/dev/keiji/deviceintegrity/provider/contract/GooglePlayIntegrityTokenProvider.kt
+++ b/android/provider/contract/src/main/java/dev/keiji/deviceintegrity/provider/contract/GooglePlayIntegrityTokenProvider.kt
@@ -3,7 +3,7 @@ package dev.keiji.deviceintegrity.provider.contract
 /**
  * Interface for providing Google Play Integrity tokens.
  */
-interface GoogleIntegrityTokenProvider {
+interface GooglePlayIntegrityTokenProvider {
     /**
      * Retrieves a Google Play Integrity token.
      *

--- a/android/provider/impl/src/main/java/dev/keiji/deviceintegrity/provider/impl/GooglePlayIntegrityTokenProviderImpl.kt
+++ b/android/provider/impl/src/main/java/dev/keiji/deviceintegrity/provider/impl/GooglePlayIntegrityTokenProviderImpl.kt
@@ -1,19 +1,19 @@
 package dev.keiji.deviceintegrity.provider.impl
 
 import android.content.Context
-import dev.keiji.deviceintegrity.provider.contract.GoogleIntegrityTokenProvider
+import dev.keiji.deviceintegrity.provider.contract.GooglePlayIntegrityTokenProvider
 import com.google.android.play.core.integrity.IntegrityManagerFactory
 import com.google.android.play.core.integrity.IntegrityTokenRequest
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject // Added for Hilt constructor injection, though Context is provided by Hilt module
 
 /**
- * Implementation of [GoogleIntegrityTokenProvider] that uses the Google Play Integrity API.
+ * Implementation of [GooglePlayIntegrityTokenProvider] that uses the Google Play Integrity API.
  */
-class GoogleIntegrityTokenProviderImpl @Inject constructor( // Mark constructor for Hilt if it's directly injected,
+class GooglePlayIntegrityTokenProviderImpl @Inject constructor( // Mark constructor for Hilt if it's directly injected,
                                                      // but here it will be constructed by a Hilt module.
     private val context: Context
-) : GoogleIntegrityTokenProvider {
+) : GooglePlayIntegrityTokenProvider {
 
     override suspend fun getToken(nonce: String): String {
         // Create an instance of a manager.

--- a/android/provider/impl/src/main/java/dev/keiji/deviceintegrity/provider/impl/di/GooglePlayIntegrityTokenProviderModule.kt
+++ b/android/provider/impl/src/main/java/dev/keiji/deviceintegrity/provider/impl/di/GooglePlayIntegrityTokenProviderModule.kt
@@ -1,8 +1,8 @@
 package dev.keiji.deviceintegrity.provider.impl.di
 
 import android.content.Context
-import dev.keiji.deviceintegrity.provider.contract.GoogleIntegrityTokenProvider
-import dev.keiji.deviceintegrity.provider.impl.GoogleIntegrityTokenProviderImpl
+import dev.keiji.deviceintegrity.provider.contract.GooglePlayIntegrityTokenProvider
+import dev.keiji.deviceintegrity.provider.impl.GooglePlayIntegrityTokenProviderImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,13 +12,13 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GoogleIntegrityTokenProviderModule {
+object GooglePlayIntegrityTokenProviderModule {
 
     @Provides
     @Singleton
-    fun provideGoogleIntegrityTokenProvider(
+    fun provideGooglePlayIntegrityTokenProvider(
         @ApplicationContext context: Context
-    ): GoogleIntegrityTokenProvider {
-        return GoogleIntegrityTokenProviderImpl(context)
+    ): GooglePlayIntegrityTokenProvider {
+        return GooglePlayIntegrityTokenProviderImpl(context)
     }
 }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/PlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/PlayIntegrityViewModel.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dev.keiji.deviceintegrity.provider.contract.GoogleIntegrityTokenProvider
+import dev.keiji.deviceintegrity.provider.contract.GooglePlayIntegrityTokenProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PlayIntegrityViewModel @Inject constructor(
-    private val tokenProvider: GoogleIntegrityTokenProvider
+    private val tokenProvider: GooglePlayIntegrityTokenProvider
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(PlayIntegrityUiState())
     val uiState: StateFlow<PlayIntegrityUiState> = _uiState.asStateFlow()


### PR DESCRIPTION
- Renamed the interface and its implementation.
- Updated the Hilt module providing the token provider.
- Updated all usages of the renamed classes/interfaces.
- Added a new Hilt module (AppIntegrityModule) in the 'app' module to include the provider module, ensuring GooglePlayIntegrityTokenProvider is available for injection in the app.
- Verified that Dagger-Hilt is correctly configured in the 'app' module.