### PR TITLE
feat: 設定画面にアプリとOSのバージョン情報を表示

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -43,6 +43,9 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/android/app/src/main/java/dev/keiji/deviceintegrity/AppInfoProviderImpl.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/AppInfoProviderImpl.kt
@@ -1,0 +1,15 @@
+package dev.keiji.deviceintegrity
+
+import dev.keiji.deviceintegrity.provider.contract.AppInfoProvider
+import javax.inject.Inject
+
+class AppInfoProviderImpl @Inject constructor() : AppInfoProvider {
+
+    override fun getAppVersionName(): String {
+        return BuildConfig.VERSION_NAME
+    }
+
+    override fun getAppVersionCode(): Long {
+        return BuildConfig.VERSION_CODE.toLong()
+    }
+}

--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/AppModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/AppModule.kt
@@ -1,0 +1,20 @@
+package dev.keiji.deviceintegrity.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dev.keiji.deviceintegrity.AppInfoProviderImpl
+import dev.keiji.deviceintegrity.provider.contract.AppInfoProvider
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AppModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAppInfoProvider(
+        appInfoProviderImpl: AppInfoProviderImpl
+    ): AppInfoProvider
+}

--- a/android/provider/contract/src/main/java/dev/keiji/deviceintegrity/provider/contract/AppInfoProvider.kt
+++ b/android/provider/contract/src/main/java/dev/keiji/deviceintegrity/provider/contract/AppInfoProvider.kt
@@ -1,0 +1,6 @@
+package dev.keiji.deviceintegrity.provider.contract
+
+interface AppInfoProvider {
+    fun getAppVersionName(): String
+    fun getAppVersionCode(): Long
+}

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/settings/SettingsScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/settings/SettingsScreen.kt
@@ -1,14 +1,17 @@
 package dev.keiji.deviceintegrity.ui.main.settings
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
@@ -17,17 +20,42 @@ fun SettingsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+    SettingsContent(uiState = uiState)
+}
+
+@Composable
+private fun SettingsContent(
+    uiState: SettingsUiState
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Text(text = "Settings Screen: ${uiState.sampleSetting}")
-        // TODO: Display actual settings UI
+        Text(
+            text = "App Version Name: ${uiState.appVersionName}",
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Text(
+            text = "App Version Code: ${uiState.appVersionCode}",
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Text(
+            text = "OS Version: ${uiState.osVersion}",
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Text(
+            text = "Security Patch Level: ${uiState.securityPatchLevel}",
+            style = MaterialTheme.typography.bodyLarge
+        )
     }
 }
 
 @Preview
 @Composable
 private fun SettingsScreenPreview() {
-    SettingsScreen()
+    // Preview uses a default SettingsUiState which will have empty strings
+    // For a more representative preview, you could mock the ViewModel or pass a sample UiState
+    SettingsContent(uiState = SettingsUiState("1.0.0", 1, "13", "2023-08-01"))
 }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/settings/SettingsUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/settings/SettingsUiState.kt
@@ -1,6 +1,8 @@
 package dev.keiji.deviceintegrity.ui.main.settings
 
 data class SettingsUiState(
-    val sampleSetting: String = "Initial Value"
-    // TODO: Add actual settings properties
+    val appVersionName: String,
+    val appVersionCode: Long,
+    val osVersion: String,
+    val securityPatchLevel: String
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/settings/SettingsViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/settings/SettingsViewModel.kt
@@ -1,13 +1,30 @@
 package dev.keiji.deviceintegrity.ui.main.settings
 
+import android.os.Build
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.keiji.deviceintegrity.provider.contract.AppInfoProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
 
-class SettingsViewModel : ViewModel() {
-    private val _uiState = MutableStateFlow(SettingsUiState())
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    appInfoProvider: AppInfoProvider
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        SettingsUiState(
+            appVersionName = appInfoProvider.getAppVersionName(),
+            appVersionCode = appInfoProvider.getAppVersionCode(),
+            osVersion = Build.VERSION.RELEASE,
+            securityPatchLevel = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                Build.VERSION.SECURITY_PATCH
+            } else {
+                "N/A" // Marshmallow以前はSECURITY_PATCHがない
+            }
+        )
+    )
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
-
-    // TODO: Implement logic to manage settings
 }

--- a/tempproperties.txt
+++ b/tempproperties.txt
@@ -1,0 +1,1 @@
+sdk.dir=/root/Android/sdk


### PR DESCRIPTION
設定タブ内に以下の情報を表示するようにしました。

- アプリケーションバージョン名 (例: 1.0.0)
- アプリケーションバージョンコード (例: 1)
- OSバージョン (例: 13)
- OSセキュリティパッチレベル (例: 2023-08-01)

主な変更点:
- AppInfoProviderインターフェースをprovider:contractモジュールに定義
- AppInfoProviderの実装をappモジュールに作成し、BuildConfigからアプリバージョンを取得
- Hiltモジュールをappモジュールに作成し、AppInfoProviderをDIできるように設定
- SettingsViewModel (ui:main) でAppInfoProviderとBuild APIを利用して各種バージョン情報を取得
- SettingsScreen (ui:main) でViewModelから取得した情報を表示
- appモジュールのbuild.gradle.ktsでBuildConfig生成を有効化