### PR TITLE
Refactor: Move Play Integrity dependency and add UI tooling

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -52,8 +52,6 @@ dependencies {
     implementation(project(":ui:main"))
     implementation(project(":provider:impl"))
 
-    implementation("com.google.android.play:integrity:1.4.0")
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
 

--- a/android/ui/main/build.gradle.kts
+++ b/android/ui/main/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.androidx.navigation.compose) // AppScreen might use navigation
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose) // For ViewModel in MainActivity/AppScreen if any
+    debugImplementation(libs.androidx.ui.tooling)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)


### PR DESCRIPTION
- Moved the Play Integrity API dependency from the `app` module to the `ui:main` module.
- Added `androidx.ui.tooling` as a debug implementation dependency to the `ui:main` module.