### PR TITLE
feat: Add /play-integrity/nonce endpoint

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,8 +1,63 @@
+import os
+import base64
+from datetime import datetime, timezone
 from flask import Flask, request, jsonify
+from google.cloud import datastore
 
 # Initialize Flask app
 # GAE expects the Flask app object to be named 'app' by default.
 app = Flask(__name__)
+
+# Initialize Datastore client
+datastore_client = datastore.Client()
+
+def generate_and_store_nonce():
+    """Generates a cryptographically secure nonce, stores it in Datastore, and returns it."""
+    # Generate 24 cryptographically secure random bytes
+    raw_nonce = os.urandom(24)
+
+    # Base64 encode the nonce
+    encoded_nonce = base64.urlsafe_b64encode(raw_nonce).decode('utf-8').rstrip('=') # Use urlsafe and remove padding
+
+    # Get current time in epoch milliseconds
+    # Using timezone.utc to ensure it's a UTC timestamp
+    now = datetime.now(timezone.utc)
+    generated_datetime_ms = int(now.timestamp() * 1000)
+
+    # Create a new Datastore entity
+    kind = "Nonce"
+    # Create a unique name/key for the entity if needed, or let Datastore generate an ID
+    # For simplicity, we'll let Datastore generate a numeric ID.
+    nonce_entity = datastore.Entity(key=datastore_client.key(kind))
+    nonce_entity.update({
+        'nonce': encoded_nonce,
+        'generated_datetime': generated_datetime_ms,
+        'created_at': now # Store the full datetime object as well for easier querying/sorting if needed
+    })
+
+    # Save the entity to Datastore
+    datastore_client.put(nonce_entity)
+
+    return encoded_nonce, generated_datetime_ms
+
+@app.route('/play-integrity/nonce', methods=['GET'])
+def create_nonce_endpoint():
+    """
+    Handles GET requests to /play-integrity/nonce.
+    Generates a nonce, saves it to Datastore, and returns it as JSON.
+    """
+    try:
+        nonce, generated_datetime = generate_and_store_nonce()
+        response = {
+            "nonce": nonce,
+            "generated_datetime": generated_datetime
+        }
+        return jsonify(response), 200
+    except Exception as e:
+        # Log the error for debugging
+        # In a production app, you might want more sophisticated error handling
+        app.logger.error(f"Error generating nonce: {e}")
+        return jsonify({"error": "Failed to generate nonce"}), 500
 
 @app.route('/play-integrity/verify', methods=['POST'])
 def verify_integrity():

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=2.0.0,<3.0.0 # Pin Flask to a version range for stability
 gunicorn>=20.0.0,<21.0.0 # Gunicorn is a common WSGI server for GAE Python apps
+google-cloud-datastore>=2.5.0,<3.0.0 # For Google Cloud Datastore access


### PR DESCRIPTION
Implements a new GET endpoint `/play-integrity/nonce` that:
- Generates a cryptographically secure 24-byte nonce.
- Base64 encodes the nonce (URL-safe, no padding).
- Stores the nonce and its generation timestamp (epoch milliseconds) in Google Cloud Datastore under the 'Nonce' kind.
- Returns the nonce and timestamp in a JSON response: {"nonce": "[base64_nonce]", "generated_datetime": [epoch_ms]}

Also adds `google-cloud-datastore` to requirements.