### PR TITLE
Refactor: Rename GooglePlayIntegrity to PlayIntegrity

### DIFF
--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/PlayIntegrityTokenRepositoryModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/PlayIntegrityTokenRepositoryModule.kt
@@ -7,20 +7,20 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dev.keiji.deviceintegrity.provider.contract.StandardIntegrityTokenProviderProvider
-import dev.keiji.deviceintegrity.repository.contract.GooglePlayIntegrityTokenRepository
-import dev.keiji.deviceintegrity.repository.impl.GooglePlayIntegrityTokenRepositoryImpl
+import dev.keiji.deviceintegrity.repository.contract.PlayIntegrityTokenRepository
+import dev.keiji.deviceintegrity.repository.impl.PlayIntegrityTokenRepositoryImpl
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GooglePlayIntegrityTokenRepositoryModule {
+object PlayIntegrityTokenRepositoryModule {
 
     @Provides
     @Singleton
-    fun provideGooglePlayIntegrityTokenRepository(
+    fun providePlayIntegrityTokenRepository(
         @ApplicationContext context: Context, // For classic requests
         standardIntegrityTokenProviderProvider: StandardIntegrityTokenProviderProvider // Provider for standard requests
-    ): GooglePlayIntegrityTokenRepository {
-        return GooglePlayIntegrityTokenRepositoryImpl(context, standardIntegrityTokenProviderProvider)
+    ): PlayIntegrityTokenRepository {
+        return PlayIntegrityTokenRepositoryImpl(context, standardIntegrityTokenProviderProvider)
     }
 }

--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/PlayIntegrityTokenRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/PlayIntegrityTokenRepository.kt
@@ -3,7 +3,7 @@ package dev.keiji.deviceintegrity.repository.contract
 /**
  * Interface for providing Google Play Integrity tokens.
  */
-interface GooglePlayIntegrityTokenRepository {
+interface PlayIntegrityTokenRepository {
     /**
      * Retrieves a Google Play Integrity token using the classic request.
      *

--- a/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityTokenRepositoryImpl.kt
+++ b/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityTokenRepositoryImpl.kt
@@ -5,17 +5,17 @@ import com.google.android.play.core.integrity.IntegrityManagerFactory
 import com.google.android.play.core.integrity.IntegrityTokenRequest
 import com.google.android.play.core.integrity.StandardIntegrityManager
 import dev.keiji.deviceintegrity.provider.contract.StandardIntegrityTokenProviderProvider
-import dev.keiji.deviceintegrity.repository.contract.GooglePlayIntegrityTokenRepository
+import dev.keiji.deviceintegrity.repository.contract.PlayIntegrityTokenRepository
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 /**
- * Implementation of [GooglePlayIntegrityTokenRepository] that uses the Google Play Integrity API.
+ * Implementation of [PlayIntegrityTokenRepository] that uses the Google Play Integrity API.
  */
-class GooglePlayIntegrityTokenRepositoryImpl @Inject constructor(
+class PlayIntegrityTokenRepositoryImpl @Inject constructor(
     private val context: Context, // Kept for classic requests
     private val standardIntegrityTokenProviderProvider: StandardIntegrityTokenProviderProvider
-) : GooglePlayIntegrityTokenRepository {
+) : PlayIntegrityTokenRepository {
 
     override suspend fun getTokenClassic(nonce: String): String {
         // Create an instance of a manager for classic requests.

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/PlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/PlayIntegrityViewModel.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dev.keiji.deviceintegrity.repository.contract.GooglePlayIntegrityTokenRepository
+import dev.keiji.deviceintegrity.repository.contract.PlayIntegrityTokenRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PlayIntegrityViewModel @Inject constructor(
-    private val tokenProvider: GooglePlayIntegrityTokenRepository
+    private val tokenProvider: PlayIntegrityTokenRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(PlayIntegrityUiState())
     val uiState: StateFlow<PlayIntegrityUiState> = _uiState.asStateFlow()


### PR DESCRIPTION
Renamed classes, interfaces, methods, and variables related to GooglePlayIntegrity to use the shorter PlayIntegrity prefix.

This change affects the following files:
- android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/PlayIntegrityTokenRepository.kt
- android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityTokenRepositoryImpl.kt
- android/app/src/main/java/dev/keiji/deviceintegrity/di/PlayIntegrityTokenRepositoryModule.kt
- android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/PlayIntegrityViewModel.kt