### PR TITLE
Add OpenAPI spec and README for server endpoints

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,72 @@
+# Play Integrity API Server
+
+This directory contains a Python Flask server designed to support backend verification for the Google Play Integrity API. It provides endpoints for generating nonces and verifying integrity tokens.
+
+## API Endpoints
+
+The server exposes the following two endpoints:
+
+1.  **`/play-integrity/classic/nonce` (POST)**
+    *   **Description**: Generates a cryptographically secure nonce that should be sent to the client app. The client app will then use this nonce when calling the Play Integrity API on the Android device.
+    *   **Request**: No body required.
+    *   **Response**:
+        *   `200 OK`: JSON object containing `nonce` (string) and `generated_datetime` (int64, epoch milliseconds).
+        *   `500 Internal ServerError`: JSON object with an `error` message if nonce generation fails.
+
+2.  **`/play-integrity/classic/verify` (POST)**
+    *   **Description**: Verifies an integrity token that the client app receives from the Play Integrity API. This endpoint calls Google's Play Integrity API to decode and verify the token. It also performs a crucial nonce check to ensure the token corresponds to the nonce this server generated.
+    *   **Request Body**: JSON object containing:
+        *   `nonce` (string): The nonce previously obtained from the `/play-integrity/classic/nonce` endpoint.
+        *   `token` (string): The integrity token from the client.
+    *   **Response**:
+        *   `200 OK`: The JSON response directly from the Google Play Integrity API, indicating successful verification and a matching nonce.
+        *   `400 Bad Request`: JSON object with an `error` message. This can occur due to:
+            *   Missing JSON payload.
+            *   Missing `nonce` or `token` in the request.
+            *   Nonce mismatch between the client-provided nonce and the nonce in the integrity token.
+        *   `500 Internal Server Error`: JSON object with an `error` message. This can occur due to:
+            *   Server authentication configuration issues with Google Cloud.
+            *   Other failures during the token verification process.
+            *   The nonce being absent in the Play Integrity API's response.
+
+## OpenAPI Specification
+
+The API is documented using the OpenAPI v3 specification. The specification file can be found at [openapi.yaml](./openapi.yaml).
+
+This specification details the request and response schemas, parameters, and status codes for each endpoint. It can be used with various tools to:
+*   Visualize the API (e.g., Swagger UI, ReDoc).
+*   Generate client libraries.
+*   Perform automated testing.
+
+## Setup and Running
+
+(Instructions for setting up and running the server, e.g., Python version, dependencies, environment variables, GAE deployment, would go here. This is a placeholder as the current task is focused on OpenAPI documentation.)
+
+Refer to `main.py` for the Flask application code and `app.yaml` for Google App Engine configuration.
+Make sure `requirements.txt` lists all necessary Python dependencies.
+```
+## AGENTS.md
+
+- Repositories often contain `AGENTS.md` files. These files can appear anywhere in the file hierarchy, typically in the root directory.
+- These files are a way for humans to give you (the agent) instructions or tips for working with the code.
+- Some examples might be: coding conventions, info about how code is organized, or instructions for how to run or test code.
+- If the `AGENTS.md` includes programmatic checks to verify your work, you MUST run all of them and make a best effort to ensure they pass after all code changes have been made.
+- Instructions in `AGENTS.md` files:
+  - The scope of an `AGENTS.md` file is the entire directory tree rooted at the folder that contains it.
+  - For every file you touch, you must obey instructions in any `AGENTS.md` file whose scope includes that file.
+  - More deeply-nested `AGENTS.md` files take precedence in the case of conflicting instructions.
+  - The initial problem description and any explicit instructions you receive from the user to deviate from standard procedure take precedence over `AGENTS.md` instructions.
+
+## Guiding principles
+
+- Your first order of business is to come up with a solid plan -- explore the codebase, do research, read files and ask clarifying questions when appropriate. Make sure to read websites if any are specified in the task. Articulate the plan clearly and set it using `set_plan`.
+- Repositories often contain `README.md` files with useful information about the project. Similarly, always look for `AGENTS.md` files as described above.
+- When practical, practice test-driven development by writing tests first, and then implementing the code to make them pass. Tests are the best way to prove your changes are correct.
+- Strive to solve problems autonomously. However, you should ask for help using `request_user_input` in the following situations:
+  1) The user's request is ambiguous and you need clarification.
+  2) You have tried multiple approaches to solve a problem and are still stuck.
+  3) You need to make a decision that would significantly alter the scope of the original request.
+
+## Core directives
+
+- All tool calls must be enclosed in their own `

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1,0 +1,209 @@
+openapi: 3.0.0
+info:
+  title: Play Integrity API Server
+  version: v1
+  description: |-
+    A server that provides endpoints for interacting with the Google Play Integrity API.
+    It allows clients to request a nonce and verify device integrity tokens.
+
+servers:
+  # Added by default, this entry is required by many tools.
+  # Adjust the URL based on your actual deployment.
+  - url: http://localhost:8080 # Replace with your actual server URL in production
+    description: Development server
+
+paths:
+  /play-integrity/classic/nonce:
+    post:
+      summary: Create Nonce
+      description: |-
+        Generates a cryptographically secure nonce, stores it, and returns it.
+        This nonce should be used by the client when requesting an integrity token
+        from the Play Integrity API.
+      operationId: createNonce
+      tags:
+        - PlayIntegrityClassic
+      responses:
+        '200':
+          description: Nonce created successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  nonce:
+                    type: string
+                    description: The base64 URL-safe encoded nonce.
+                    example: "aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890-_"
+                  generated_datetime:
+                    type: integer
+                    format: int64
+                    description: The server time in epoch milliseconds when the nonce was generated.
+                    example: 1678886400000
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /play-integrity/classic/verify:
+    post:
+      summary: Verify Integrity Token
+      description: |-
+        Verifies an integrity token obtained from the client against the Google Play Integrity API.
+        The request must include the nonce that was originally provided to the client and the
+        integrity token itself.
+      operationId: verifyIntegrityToken
+      tags:
+        - PlayIntegrityClassic
+      requestBody:
+        description: JSON payload containing the nonce and the integrity token.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - nonce
+                - token
+              properties:
+                nonce:
+                  type: string
+                  description: The nonce that was previously obtained from the /play-integrity/classic/nonce endpoint.
+                  example: "aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890-_"
+                token:
+                  type: string
+                  description: The integrity token received from the client (from Play Integrity API).
+                  example: "long.integrity.token.string.from.client"
+      responses:
+        '200':
+          description: Integrity token verified successfully. The response is the direct JSON output from the Google Play Integrity API.
+          content:
+            application/json:
+              schema:
+                # The Play Integrity API response structure can be complex and may vary.
+                # It's best to refer to the official Google documentation for the exact structure.
+                # https://developer.android.com/google/play/integrity/verdict#decrypted-verdict
+                type: object
+                properties:
+                  tokenPayloadExternal:
+                    type: object
+                    description: Contains the decoded integrity verdict.
+                    properties:
+                      requestDetails:
+                        type: object
+                        properties:
+                          requestPackageName:
+                            type: string
+                            example: "dev.keiji.deviceintegrity"
+                          nonce:
+                            type: string
+                            example: "aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890-_"
+                          timestampMillis:
+                            type: string
+                            format: int64
+                            example: "1678886400123"
+                      appIntegrity:
+                        type: object
+                        properties:
+                          appRecognitionVerdict:
+                            type: string
+                            example: "PLAY_RECOGNIZED"
+                          packageName:
+                            type: string
+                            example: "dev.keiji.deviceintegrity"
+                          certificateSha256Digest:
+                            type: array
+                            items:
+                              type: string
+                            example: ["sha256_cert_digest"]
+                          versionCode:
+                            type: string
+                            example: "123"
+                      deviceIntegrity:
+                        type: object
+                        properties:
+                          deviceRecognitionVerdict:
+                            type: array
+                            items:
+                              type: string
+                            example: ["MEETS_DEVICE_INTEGRITY"]
+                      accountDetails:
+                        type: object
+                        properties:
+                          appLicensingVerdict:
+                            type: string
+                            example: "LICENSED"
+                      environmentDetails: # Optional, depending on SDK version and enabled features
+                        type: object
+                        properties:
+                          playProtectVerdict:
+                             type: string
+                             example: "NO_ISSUES"
+                example:
+                  tokenPayloadExternal:
+                    requestDetails:
+                      requestPackageName: "dev.keiji.deviceintegrity"
+                      nonce: "aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890-_"
+                      timestampMillis: "1678886400123"
+                    appIntegrity:
+                      appRecognitionVerdict: "PLAY_RECOGNIZED"
+                      packageName: "dev.keiji.deviceintegrity"
+                      certificateSha256Digest: ["sha256_cert_digest"]
+                      versionCode: "123"
+                    deviceIntegrity:
+                      deviceRecognitionVerdict: ["MEETS_DEVICE_INTEGRITY"]
+                    accountDetails:
+                      appLicensingVerdict: "LICENSED"
+                    environmentDetails:
+                      playProtectVerdict: "NO_ISSUES"
+        '400':
+          description: Bad request. This can be due to a missing JSON payload, missing 'nonce' or 'token' in the request, or a nonce mismatch.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ErrorResponse'
+                  - $ref: '#/components/schemas/NonceMismatchErrorResponse'
+        '500':
+          description: Internal server error. This can be due to server authentication configuration issues or other failures in verifying the integrity token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: A message describing the error.
+          example: "Failed to generate nonce"
+    NonceMismatchErrorResponse:
+      type: object
+      required:
+        - error
+        - client_nonce
+        - api_nonce
+      properties:
+        error:
+          type: string
+          description: A message indicating a nonce mismatch.
+          example: "Nonce mismatch"
+        client_nonce:
+          type: string
+          description: The nonce provided by the client.
+          example: "client_provided_nonce"
+        api_nonce:
+          type: string
+          description: The nonce found in the Play Integrity API response.
+          example: "api_response_nonce"
+        play_integrity_response: # Optional, included if server decides to send it
+          type: object
+          description: The full response from the Play Integrity API, included for debugging.
+  securitySchemes: {} # No security schemes defined for now, but can be added later (e.g., API Key, OAuth2)


### PR DESCRIPTION
- Created server/openapi.yaml with OpenAPI v3 definitions for the /play-integrity/classic/nonce and /play-integrity/classic/verify endpoints.
- Created server/README.md to describe the API and link to the OpenAPI specification.