### PR TITLE
Fix: Use spectral:oas ruleset for OpenAPI linting

### DIFF
--- a/.github/workflows/openapi_lint.yml
+++ b/.github/workflows/openapi_lint.yml
@@ -24,4 +24,4 @@ jobs:
         run: npm install -g @stoplight/spectral-cli
 
       - name: Run Spectral lint
-        run: spectral lint server/openapi.yaml
+        run: spectral lint server/openapi.yaml --ruleset spectral:oas


### PR DESCRIPTION
This commit updates the GitHub Actions workflow for OpenAPI linting to use the recommended `spectral:oas` ruleset. This resolves an error where Spectral could not find a ruleset to use.