### PR TITLE
Enable Gradle configuration cache

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Enables configuration caching for faster builds
+org.gradle.configuration-cache=true


### PR DESCRIPTION
This change enables the Gradle configuration cache by setting `org.gradle.configuration-cache=true` in `gradle.properties` for potentially faster builds.