### PR TITLE
Inject ApiEndpointSettingsNavigator into MainActivity

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
@@ -33,6 +33,7 @@ import dev.keiji.deviceintegrity.ui.main.keyattestation.KeyAttestationViewModel
 import dev.keiji.deviceintegrity.ui.main.keyattestation.KeyAttestationUiEvent
 import dev.keiji.deviceintegrity.ui.main.settings.SettingsViewModel
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.keiji.deviceintegrity.ui.nav.contract.ApiEndpointSettingsNavigator
 import timber.log.Timber


### PR DESCRIPTION
- Injected ApiEndpointSettingsNavigator directly into MainActivity.
- Passed the navigator to Composable functions down to SettingsScreen.
- Used ActivityResultLauncher in the SettingsScreen's composable scope within MainActivity to navigate to ApiEndpointSettingsActivity.