### PR TITLE
feat: Use Kotlinx Serialization for Retrofit

### DIFF
--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/AppModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/AppModule.kt
@@ -7,12 +7,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dev.keiji.deviceintegrity.AppInfoProviderImpl
 import dev.keiji.deviceintegrity.provider.contract.AppInfoProvider
-import dev.keiji.deviceintegrity.api.playintegrity.PlayIntegrityTokenVerifyApi // Import
-import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import retrofit2.Retrofit
-import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -25,47 +19,5 @@ object AppModule {
         impl: AppInfoProviderImpl
     ): AppInfoProvider {
         return impl
-    }
-
-    @Provides
-    @Singleton
-    fun provideOkHttpClient(): OkHttpClient {
-        return OkHttpClient.Builder()
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
-            .writeTimeout(30, TimeUnit.SECONDS)
-            .build()
-    }
-
-    @Provides
-    @Singleton
-    fun provideJson(): Json {
-        return Json {
-            ignoreUnknownKeys = true
-            coerceInputValues = true
-        }
-    }
-
-    @Provides
-    @Singleton
-    fun provideRetrofit(
-        okHttpClient: OkHttpClient,
-        json: Json
-    ): Retrofit {
-        // TODO: Replace with actual base URL from configuration
-        val baseUrl = "http://10.0.2.2:8080/" // For Android emulator to connect to host machine
-        return Retrofit.Builder()
-            .baseUrl(baseUrl)
-            .client(okHttpClient)
-            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-            .build()
-    }
-
-    @Provides
-    @Singleton
-    fun providePlayIntegrityTokenVerifyApi(
-        retrofit: Retrofit
-    ): PlayIntegrityTokenVerifyApi {
-        return retrofit.create(PlayIntegrityTokenVerifyApi::class.java)
     }
 }

--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/NetworkModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/NetworkModule.kt
@@ -6,9 +6,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dev.keiji.deviceintegrity.di.qualifier.KeyAttestation
 import dev.keiji.deviceintegrity.di.qualifier.PlayIntegrity
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import javax.inject.Singleton
 
 @Module
@@ -29,10 +31,11 @@ object NetworkModule {
     @Singleton
     @PlayIntegrity
     fun providePlayIntegrityRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        val json = Json { ignoreUnknownKeys = true }
         return Retrofit.Builder()
             .baseUrl(PLAY_INTEGRITY_BASE_URL)
             .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create())
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
     }
 
@@ -40,10 +43,11 @@ object NetworkModule {
     @Singleton
     @KeyAttestation
     fun provideKeyAttestationRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        val json = Json { ignoreUnknownKeys = true }
         return Retrofit.Builder()
             .baseUrl(KEY_ATTESTATION_BASE_URL)
             .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create())
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
     }
 

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.keiji.deviceintegrity.api.playintegrity.CreateNonceRequest // Import
-import dev.keiji.deviceintegrity.api.playintegrity.PlayIntegrityTokenVerifyApi // Import
+import dev.keiji.deviceintegrity.api.playintegrity.PlayIntegrityTokenVerifyApiClient // Import
 import dev.keiji.deviceintegrity.api.playintegrity.VerifyTokenRequest
 import dev.keiji.deviceintegrity.repository.contract.PlayIntegrityTokenRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +19,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ClassicPlayIntegrityViewModel @Inject constructor(
     private val tokenProvider: PlayIntegrityTokenRepository,
-    private val playIntegrityTokenVerifyApi: PlayIntegrityTokenVerifyApi // Inject API
+    private val playIntegrityTokenVerifyApi: PlayIntegrityTokenVerifyApiClient // Inject API
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ClassicPlayIntegrityUiState())
     val uiState: StateFlow<ClassicPlayIntegrityUiState> = _uiState.asStateFlow()


### PR DESCRIPTION
- Replaced MoshiConverterFactory with KotlinxSerializationConverterFactory in NetworkModule.
- Resolved Hilt duplicate binding errors by removing OkHttpClient and Retrofit provisions from AppModule.