### PR TITLE
Add Dockerfiles for Cloud Run migration and update README

### DIFF
--- a/server/key_attestation/.dockerignore
+++ b/server/key_attestation/.dockerignore
@@ -1,0 +1,31 @@
+# Git files
+.git
+.gitignore
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environment
+venv/
+env/
+.venv/
+
+# IDE and editor files
+.idea/
+*.swp
+*.swo
+
+# App Engine specific files
+app.yaml
+lib/
+
+# Other
+.DS_Store
+Dockerfile
+README.md
+tests/
+requirements-dev.txt
+docker-compose.yml

--- a/server/key_attestation/Dockerfile
+++ b/server/key_attestation/Dockerfile
@@ -1,0 +1,24 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the current directory contents into the container at /app
+COPY . .
+
+# Make port $PORT available to the world outside this container
+# Cloud Run sets this environment variable.
+EXPOSE $PORT
+
+# Define environment variable
+ENV PORT 8080
+
+# Run app.py when the container launches
+CMD exec gunicorn -b :$PORT key_attestation:app

--- a/server/play_integrity/.dockerignore
+++ b/server/play_integrity/.dockerignore
@@ -1,0 +1,31 @@
+# Git files
+.git
+.gitignore
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environment
+venv/
+env/
+.venv/
+
+# IDE and editor files
+.idea/
+*.swp
+*.swo
+
+# App Engine specific files
+app.yaml
+lib/
+
+# Other
+.DS_Store
+Dockerfile
+README.md
+tests/
+requirements-dev.txt
+docker-compose.yml

--- a/server/play_integrity/Dockerfile
+++ b/server/play_integrity/Dockerfile
@@ -1,0 +1,24 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the current directory contents into the container at /app
+COPY . .
+
+# Make port $PORT available to the world outside this container
+# Cloud Run sets this environment variable.
+EXPOSE $PORT
+
+# Define environment variable
+ENV PORT 8080
+
+# Run app.py when the container launches
+CMD exec gunicorn -b :$PORT play_integrity:app


### PR DESCRIPTION
- Add Dockerfile and .dockerignore for key_attestation service.
- Add Dockerfile and .dockerignore for play_integrity service.
- Update server/README.md with deployment instructions for Cloud Run.