### PR TITLE
Refactor: RetrofitのベースURLをBuildConfigFieldで定数化

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -25,6 +25,8 @@ android {
 
         // TODO: Replace 0L with your actual Google Cloud Project Number
         buildConfigField("Long", "PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER", "0L")
+        buildConfigField("String", "PLAY_INTEGRITY_BASE_URL", "\"https://playintegrity.googleapis.com/\"")
+        buildConfigField("String", "KEY_ATTESTATION_BASE_URL", "\"https://keyattestation.googleapis.com/\"")
     }
 
     buildTypes {

--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/NetworkModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/NetworkModule.kt
@@ -11,14 +11,12 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dev.keiji.deviceintegrity.BuildConfig
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
-
-    private const val PLAY_INTEGRITY_BASE_URL = "https://playintegrity.googleapis.com/"
-    private const val KEY_ATTESTATION_BASE_URL = "https://keyattestation.googleapis.com/"
 
     @Provides
     @Singleton
@@ -33,7 +31,7 @@ object NetworkModule {
     fun providePlayIntegrityRetrofit(okHttpClient: OkHttpClient): Retrofit {
         val json = Json { ignoreUnknownKeys = true }
         return Retrofit.Builder()
-            .baseUrl(PLAY_INTEGRITY_BASE_URL)
+            .baseUrl(BuildConfig.PLAY_INTEGRITY_BASE_URL)
             .client(okHttpClient)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
@@ -45,7 +43,7 @@ object NetworkModule {
     fun provideKeyAttestationRetrofit(okHttpClient: OkHttpClient): Retrofit {
         val json = Json { ignoreUnknownKeys = true }
         return Retrofit.Builder()
-            .baseUrl(KEY_ATTESTATION_BASE_URL)
+            .baseUrl(BuildConfig.KEY_ATTESTATION_BASE_URL)
             .client(okHttpClient)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()


### PR DESCRIPTION
Retrofitで使用しているKey Attestation APIとPlay Integrity APIのベースURLを`android/app/build.gradle.kts`の`buildConfigField`で定義するように変更しました。

これにより、URLの変更が容易になり、異なるビルドバリアントで異なるエンドポイントを指定することも可能になります。