### PR TITLE
Refactor: Clarify nonce is Base64 encoded for Play Integrity API

### DIFF
--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/PlayIntegrityTokenRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/PlayIntegrityTokenRepository.kt
@@ -7,14 +7,15 @@ interface PlayIntegrityTokenRepository {
     /**
      * Retrieves a Google Play Integrity token using the classic request.
      *
-     * @param nonce A unique string that the server should generate and send to the client app.
-     *              This nonce will be included in the signed integrity token.
+     * @param nonceBase64 A unique string that the server should generate and send to the client app.
+     *                    This nonce will be included in the signed integrity token.
+     *                    It must be Base64 encoded in web-safe no-wrap form.
      * @return The integrity token as a String.
      * @throws Exception if there is an issue retrieving the token. The specific exception
      *                   type will depend on the underlying cause (e.g., network issues,
      *                   Play Services not available, Integrity API errors).
      */
-    suspend fun getTokenClassic(nonce: String): String
+    suspend fun getTokenClassic(nonceBase64: String): String
 
     /**
      * Retrieves a Google Play Integrity token using the standard request.

--- a/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityTokenRepositoryImpl.kt
+++ b/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityTokenRepositoryImpl.kt
@@ -17,14 +17,22 @@ class PlayIntegrityTokenRepositoryImpl @Inject constructor(
     private val standardIntegrityTokenProviderProvider: StandardIntegrityTokenProviderProvider
 ) : PlayIntegrityTokenRepository {
 
-    override suspend fun getTokenClassic(nonce: String): String {
+    /**
+     * Retrieves a classic integrity token.
+     *
+     * @param nonceBase64 The nonce to bind the integrity token to.
+     *                    It must be Base64 encoded in web-safe no-wrap form.
+     * @return The integrity token.
+     * @throws IllegalStateException If the integrity token is null.
+     */
+    override suspend fun getTokenClassic(nonceBase64: String): String {
         // Create an instance of a manager for classic requests.
         val integrityManager = IntegrityManagerFactory.create(context.applicationContext)
 
         // Request the integrity token by providing a nonce.
         val tokenResponse = integrityManager.requestIntegrityToken(
             IntegrityTokenRequest.builder()
-                .setNonce(nonce)
+                .setNonce(nonceBase64)
                 .build()
         ).await()
 


### PR DESCRIPTION
The nonce parameter for `getTokenClassic` in `PlayIntegrityTokenRepository` and its implementation `PlayIntegrityTokenRepositoryImpl` has been renamed to `nonceBase64` to clearly indicate that it must be Base64 encoded.

The KDoc comments have also been updated to reflect this requirement, aligning with the Play Integrity API documentation which specifies that the nonce must be Base64 encoded in web-safe no-wrap form.