### PR TITLE
Remove unnecessary package attributes from AndroidManifest.xml files

### DIFF
--- a/android/api/src/main/AndroidManifest.xml
+++ b/android/api/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.keiji.deviceintegrity.api">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/android/ui/main/src/main/AndroidManifest.xml
+++ b/android/ui/main/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.keiji.deviceintegrity.ui.main">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity

--- a/android/ui/theme/src/main/AndroidManifest.xml
+++ b/android/ui/theme/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.keiji.deviceintegrity.ui.theme">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
AGP 8.0+ recommends removing the package attribute from library module AndroidManifest.xml files, as the namespace in build.gradle serves this purpose.