### PR TITLE
Fix: Adjust SettingsMenuItem height to allow multi-line text

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/settings/SettingsScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/settings/SettingsScreen.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -91,7 +91,7 @@ fun SettingsMenuItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start,
             modifier = Modifier
-                .height(48.dp)
+                .defaultMinSize(minHeight = 48.dp)
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
             if (icon != null) {


### PR DESCRIPTION
Changed Modifier.height(48.dp) to Modifier.defaultMinSize(minHeight = 48.dp) in SettingsMenuItem to ensure that multi-line subtitles are fully visible.