### PR TITLE
Fix: Update google-api-python-client version for Play Integrity

### DIFF
--- a/server/play_integrity/requirements.txt
+++ b/server/play_integrity/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=2.0.0,<3.0.0 # Pin Flask to a version range for stability
 gunicorn>=20.0.0,<21.0.0 # Gunicorn is a common WSGI server for GAE Python apps
 google-cloud-datastore>=2.5.0,<3.0.0 # For Google Cloud Datastore access
-google-api-python-client>=2.0.0,<3.0.0 # For calling Google APIs, including Play Integrity
+google-api-python-client>=2.174.0,<3.0.0 # For calling Google APIs, including Play Integrity
 google-auth>=2.0.0,<3.0.0 # For authentication with Google Cloud services


### PR DESCRIPTION
Attempt to resolve 'AttributeError: 'Resource' object has no attribute 'decodeIntegrityToken'' by updating the google-api-python-client to version 2.174.0 as requested.

This version is expected to be available around June 24th. If installation issues occur due to unavailability, the version may need to be revisited.