### PR TITLE
Fix: Use rootProject for server-endpoint.properties path

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -16,7 +16,7 @@ val versionProps = if (versionPropertiesFile.exists()) {
     Properties() // Empty Properties object
 }
 
-val serverEndpointPropertiesFile = project.file("server-endpoint.properties")
+val serverEndpointPropertiesFile = rootProject.file("server-endpoint.properties")
 val serverEndpointProps: Properties = if (serverEndpointPropertiesFile.exists()) {
     GUtil.loadProperties(serverEndpointPropertiesFile)
 } else {


### PR DESCRIPTION
Changed app/build.gradle.kts to use rootProject.file for locating the server-endpoint.properties file. This ensures the file is correctly found from the project root directory.