### PR TITLE
Update path to version.properties

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
-val versionPropertiesFile = rootProject.file("android/version.properties")
+val versionPropertiesFile = rootProject.file("version.properties")
 val versionProps = if (versionPropertiesFile.exists()) {
     GUtil.loadProperties(versionPropertiesFile)
 } else {


### PR DESCRIPTION
Changed the path in android/app/build.gradle.kts to point to version.properties in the project root directory instead of the android directory.