### PR TITLE
Fix: Make requestHash optional in RequestDetails

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/playintegrity/PlayIntegrityTokenVerifyApiClient.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/playintegrity/PlayIntegrityTokenVerifyApiClient.kt
@@ -76,8 +76,8 @@ data class VerifyTokenResponse(
 @Serializable
 data class RequestDetails(
     val requestPackageName: String?,
-    val nonce: String? = null,
-    val requestHash: String? = null,
+    val nonce: String? = null, // Classic API
+    val requestHash: String? = null, // Standard API
     @SerialName("timestampMillis") val timestampMillis: Long?
 )
 


### PR DESCRIPTION
The `requestHash` field is not present in the Play Integrity API response for classic requests. This change makes the field optional in the `RequestDetails` data class to prevent deserialization errors when handling responses from the classic verify endpoint.