### PR TITLE
feat: Configure Cloud Run deploy to trigger on main branch server changes

### DIFF
--- a/.github/workflows/cloud_run_deploy.yml
+++ b/.github/workflows/cloud_run_deploy.yml
@@ -3,7 +3,9 @@ name: Deploy to Cloud Run
 on:
   push:
     branches:
-      - deploy/cloudrun
+      - main
+    paths:
+      - 'server/**'
 
 env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
Updates the GitHub Actions workflow for Cloud Run deployment.

The workflow will now trigger only when changes are pushed to the
main branch and a file within the 'server/' directory is modified.