### PR TITLE
Temporarily hide Key Attestation tab

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/AppScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/AppScreen.kt
@@ -14,6 +14,6 @@ sealed class AppScreen(
 
 val bottomNavigationItems = listOf(
     AppScreen.PlayIntegrity,
-    AppScreen.KeyAttestation,
+    // AppScreen.KeyAttestation,
     AppScreen.Settings
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
@@ -127,6 +127,7 @@ fun DeviceIntegrityApp(
                         onStandardRequestVerify = { standardViewModel.verifyToken() }
                     )
                 }
+                /*
                 composable(AppScreen.KeyAttestation.route) {
                     val viewModel: KeyAttestationViewModel = hiltViewModel()
                     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -148,6 +149,7 @@ fun DeviceIntegrityApp(
                         onSubmit = viewModel::submit
                     )
                 }
+                */
                 composable(AppScreen.Settings.route) {
                     val viewModel: SettingsViewModel = hiltViewModel()
                     val uiState by viewModel.uiState.collectAsStateWithLifecycle()


### PR DESCRIPTION
Commented out Key Attestation tab from the bottom navigation and disabled its navigation route in MainActivity.