### PR TITLE
refactor: Use constant for token verification delay

### DIFF
--- a/android/app/src/main/java/dev/keiji/deviceintegrity/common/Constants.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/common/Constants.kt
@@ -1,3 +1,0 @@
-package dev.keiji.deviceintegrity.common
-
-const val VERIFY_TOKEN_DELAY_MS = 20000L

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/common/Constants.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/common/Constants.kt
@@ -1,0 +1,3 @@
+package dev.keiji.deviceintegrity.ui.main.common
+
+const val VERIFY_TOKEN_DELAY_MS = 20000L

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
@@ -12,7 +12,7 @@ import dev.keiji.deviceintegrity.provider.contract.DeviceSecurityStateProvider
 import dev.keiji.deviceintegrity.repository.contract.ClassicPlayIntegrityTokenRepository
 import dev.keiji.deviceintegrity.api.playintegrity.DeviceInfo // Added
 import dev.keiji.deviceintegrity.api.playintegrity.SecurityInfo // Added
-import dev.keiji.deviceintegrity.common.VERIFY_TOKEN_DELAY_MS // Added constant
+import dev.keiji.deviceintegrity.ui.main.common.VERIFY_TOKEN_DELAY_MS // Updated import
 import kotlinx.coroutines.delay // Added for 20-second delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityViewModel.kt
@@ -12,7 +12,7 @@ import dev.keiji.deviceintegrity.provider.contract.DeviceSecurityStateProvider
 import dev.keiji.deviceintegrity.repository.contract.StandardPlayIntegrityTokenRepository
 import dev.keiji.deviceintegrity.api.playintegrity.DeviceInfo // Added
 import dev.keiji.deviceintegrity.api.playintegrity.SecurityInfo // Added
-import dev.keiji.deviceintegrity.common.VERIFY_TOKEN_DELAY_MS // Added constant
+import dev.keiji.deviceintegrity.ui.main.common.VERIFY_TOKEN_DELAY_MS // Updated import
 import kotlinx.coroutines.delay // Added for 20-second delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow


### PR DESCRIPTION
Replaces the magic number 20000ms with the
`VERIFY_TOKEN_DELAY_MS` constant for the delay duration in token verification logic.