### PR TITLE
Fix: Adjust scroll for IME in Play Integrity screens

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -32,7 +33,8 @@ fun ClassicPlayIntegrityContent(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(scrollState)
-            .padding(16.dp),
+            .padding(16.dp)
+            .imePadding(),
         horizontalAlignment = Alignment.Start, // Align labels to the left
         verticalArrangement = Arrangement.Top
     ) {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -33,7 +34,8 @@ fun StandardPlayIntegrityContent(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(scrollState)
-            .padding(16.dp),
+            .padding(16.dp)
+            .imePadding(),
         horizontalAlignment = Alignment.Start, // Align labels to the left
         verticalArrangement = Arrangement.Top
     ) {


### PR DESCRIPTION
Added imePadding() to the Classic and Standard Play Integrity screens to ensure content adjusts correctly when the keyboard is visible.