### PR TITLE
Reduce token verification delay to 5 seconds

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/common/Constants.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/common/Constants.kt
@@ -1,4 +1,4 @@
 package dev.keiji.deviceintegrity.ui.main.common
 
-const val VERIFY_TOKEN_DELAY_MS = 20000L
+const val VERIFY_TOKEN_DELAY_MS = 5000L
 const val DEBUG_VERIFY_TOKEN_DELAY_MS = 2000L


### PR DESCRIPTION
Changed `VERIFY_TOKEN_DELAY_MS` from 20000L to 5000L. `DEBUG_VERIFY_TOKEN_DELAY_MS` remains at 2000L.