### PR TITLE
Enable Edge-to-Edge for AgreementActivity

### DIFF
--- a/android/ui/agreement/src/main/java/dev/keiji/deviceintegrity/ui/agreement/AgreementActivity.kt
+++ b/android/ui/agreement/src/main/java/dev/keiji/deviceintegrity/ui/agreement/AgreementActivity.kt
@@ -8,10 +8,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -26,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import dev.keiji.deviceintegrity.provider.contract.UrlProvider
@@ -39,6 +43,7 @@ class AgreementActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             DeviceIntegrityTheme {
                 val uriHandler = LocalUriHandler.current
@@ -84,6 +89,7 @@ fun AgreementScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars)
             .padding(16.dp),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.Start


### PR DESCRIPTION
This change enables Edge-to-Edge display for the AgreementActivity by:
- Calling `WindowCompat.setDecorFitsSystemWindows(window, false)` in `onCreate`.
- Applying `windowInsetsPadding(WindowInsets.systemBars)` to the root Composable in `AgreementScreen`.