### PR TITLE
feat: Increase button height to 48dp

### DIFF
--- a/android/ui/agreement/src/main/java/dev/keiji/deviceintegrity/ui/agreement/AgreementActivity.kt
+++ b/android/ui/agreement/src/main/java/dev/keiji/deviceintegrity/ui/agreement/AgreementActivity.kt
@@ -33,6 +33,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import dev.keiji.deviceintegrity.provider.contract.UrlProvider
+import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 import dev.keiji.deviceintegrity.ui.theme.DeviceIntegrityTheme
 import kotlinx.coroutines.flow.collectLatest
 
@@ -111,14 +112,18 @@ fun AgreementScreen(
         Spacer(modifier = Modifier.weight(1f))
         OutlinedButton(
             onClick = onAgree,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ButtonHeight)
         ) {
             Text("利用を開始する")
         }
         Spacer(modifier = Modifier.height(8.dp))
         Button(
             onClick = onDisagree,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ButtonHeight)
         ) {
             Text("アプリを終了")
         }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 
 @Composable
 fun KeyAttestationScreen(
@@ -57,7 +58,9 @@ fun KeyAttestationScreen(
 
         Button(
             onClick = { onSubmit() }, // Use callback
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ButtonHeight)
         ) {
             Text(text = "送信")
         }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 
 @Composable
 fun ClassicPlayIntegrityContent(
@@ -42,7 +43,9 @@ fun ClassicPlayIntegrityContent(
         Button(
             onClick = { onFetchNonce() },
             enabled = uiState.isFetchNonceButtonEnabled,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ButtonHeight)
         ) {
             Text(text = "Fetch Nonce")
         }
@@ -56,7 +59,9 @@ fun ClassicPlayIntegrityContent(
         Button(
             onClick = { onRequestToken() },
             enabled = uiState.isRequestTokenButtonEnabled,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ButtonHeight)
         ) {
             Text(text = "Request Integrity Token")
         }
@@ -67,7 +72,9 @@ fun ClassicPlayIntegrityContent(
         Button(
             onClick = { onRequestVerify() },
             enabled = uiState.isVerifyTokenButtonEnabled,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ButtonHeight)
         ) {
             Text(text = "Request Verify Token")
         }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 
 @Composable
 fun StandardPlayIntegrityContent(
@@ -55,7 +56,9 @@ fun StandardPlayIntegrityContent(
         Button(
             onClick = { onRequestToken() },
             enabled = uiState.isRequestTokenButtonEnabled,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ButtonHeight)
         ) {
             Text(text = "Request Integrity Token")
         }
@@ -71,7 +74,9 @@ fun StandardPlayIntegrityContent(
         Button(
             onClick = { onRequestVerify() },
             enabled = uiState.isVerifyTokenButtonEnabled,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ButtonHeight)
         ) {
             Text(text = "Request Verify Token")
         }

--- a/android/ui/theme/src/main/java/dev/keiji/deviceintegrity/ui/theme/Dimensions.kt
+++ b/android/ui/theme/src/main/java/dev/keiji/deviceintegrity/ui/theme/Dimensions.kt
@@ -1,0 +1,5 @@
+package dev.keiji.deviceintegrity.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+val ButtonHeight = 48.dp


### PR DESCRIPTION
Introduced a common dimension `ButtonHeight = 48.dp` in `Dimensions.kt`
and applied it to Button and OutlinedButton components across various screens
to ensure a consistent look and feel.

Affected screens:
- AgreementActivity
- KeyAttestationScreen
- ClassicPlayIntegrityContent
- StandardPlayIntegrityContent