### PR TITLE
Fix: Resolve workflow error by using negation pattern

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -8,16 +8,14 @@ on:
     branches: [ "main" ]
     paths:
       - 'android/**'
+      - '!.android/docs/**'
       - '.github/workflows/build_check.yml' # To ensure changes to the workflow itself are checked
-    paths-ignore:
-      - 'android/docs/**'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'android/**'
+      - '!.android/docs/**'
       - '.github/workflows/build_check.yml' # To ensure changes to the workflow itself are checked
-    paths-ignore:
-      - 'android/docs/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Replaced paths-ignore with a negation pattern in paths to resolve the "you may only define one of `paths` and `paths-ignore` for a single event" error in the GitHub Actions workflow.