### PR TITLE
Adjust Play Integrity Classic behavior

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
@@ -49,6 +49,9 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
         }
         viewModelScope.launch {
             try {
+                // Add a 5-second delay
+                delay(5000)
+
                 val request = CreateNonceRequest(sessionId = currentSessionId) // Use currentSessionId
                 val response = playIntegrityTokenVerifyApi.getNonce(request)
                 _uiState.update {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/PlayIntegrityStatusComposables.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/PlayIntegrityStatusComposables.kt
@@ -175,8 +175,41 @@ fun StatusDisplayArea(
                 }
             }
         }
-        // If progressValue != 0.0F and no error messages, only progress indicator will be shown.
+        // If progressValue != 0.0F and no error messages, only progress indicator will be shown,
+        // unless it's a LinearProgressIndicator, in which case status text is also shown.
         // If progressValue == 0.0F, no errors, no response data, and statusText is empty, nothing will be shown.
+        else if (statusText.isNotEmpty() && progressValue > 0.0F) { // Show status text with LinearProgressIndicator
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                IconButton(
+                    onClick = { clipboardManager.setText(AnnotatedString(statusText)) }
+                ) {
+                    Icon(painterResource(id = R.drawable.ic_content_copy), contentDescription = "Copy Status")
+                }
+                IconButton(
+                    onClick = {
+                        val sendIntent: Intent = Intent().apply {
+                            action = Intent.ACTION_SEND
+                            putExtra(Intent.EXTRA_TEXT, statusText)
+                            type = "text/plain"
+                        }
+                        val shareIntent = Intent.createChooser(sendIntent, null)
+                        context.startActivity(shareIntent)
+                    }
+                ) {
+                    Icon(painterResource(id = R.drawable.ic_share), contentDescription = "Share Status")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            SelectionContainer {
+                Text(
+                    text = statusText,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adjust Play Integrity Classic behavior

This commit introduces the following changes to the Play Integrity Classic flow:

- Adds a 5-second delay after tapping "Fetch Nonce" before contacting the server.
- Modifies the status text visibility:
    - Status text remains visible when the HorizontalProgressIndicator is shown.
    - Status text is hidden when the CircularProgressIndicator is shown.