### PR TITLE
Fix unresolved reference errors related to Retrofit

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import java.util.UUID // Import
 import javax.inject.Inject
 // PlayIntegrityProgressConstants will be imported from the new common file
@@ -79,7 +80,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 Log.e("ClassicPlayIntegrityVM", "Error fetching nonce", e)
-                val errorMessage = if (e is retrofit2.HttpException) {
+                val errorMessage = if (e is HttpException) {
                     val errorBody = e.response()?.errorBody()?.string() ?: "No additional error information."
                     "Error fetching nonce: ${e.code()} - $errorBody"
                 } else {
@@ -248,7 +249,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 Log.e("ClassicPlayIntegrityVM", "Error verifying token with server", e)
-                val errorMessage = if (e is retrofit2.HttpException) {
+                val errorMessage = if (e is HttpException) {
                     val errorBody = e.response()?.errorBody()?.string() ?: "No additional error information."
                     "Error verifying token: ${e.code()} - $errorBody"
                 } else {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.security.MessageDigest
 import android.util.Base64
+import retrofit2.HttpException
 import java.util.UUID
 import javax.inject.Inject
 
@@ -124,7 +125,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 Log.e("StandardPlayIntegrityVM", "Error fetching integrity token (Standard)", e)
-                val errorMessage = if (e is retrofit2.HttpException) {
+                val errorMessage = if (e is HttpException) {
                     val errorBody = e.response()?.errorBody()?.string() ?: "No additional error information."
                     "Error fetching integrity token (Standard): ${e.code()} - $errorBody"
                 } else {
@@ -259,7 +260,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 Log.e("StandardPlayIntegrityVM", "Error verifying token with server", e)
-                val errorMessage = if (e is retrofit2.HttpException) {
+                val errorMessage = if (e is HttpException) {
                     val errorBody = e.response()?.errorBody()?.string() ?: "No additional error information."
                     "Error verifying token: ${e.code()} - $errorBody"
                 } else {


### PR DESCRIPTION
- Added missing import for retrofit2.HttpException in ClassicPlayIntegrityViewModel.kt and StandardPlayIntegrityViewModel.kt.
- Ensured that HttpException is used directly after import.