### PR TITLE
Fix: Optimize Android module dependencies

### DIFF
--- a/android/api/build.gradle.kts
+++ b/android/api/build.gradle.kts
@@ -35,8 +35,6 @@ android {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
-    // implementation(libs.androidx.appcompat) // Removed as it's not in libs.versions.toml and likely not needed for an api module
-    // implementation(libs.com.google.android.material) // Removed as it's not in libs.versions.toml and likely not needed for an api module
 
     // Retrofit
     implementation(libs.retrofit.core)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -108,7 +108,6 @@ dependencies {
     implementation(project(":provider:contract"))
     implementation(project(":repository:impl"))
     implementation(project(":ui:nav:impl"))
-    implementation(project(":api"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/android/provider/contract/build.gradle.kts
+++ b/android/provider/contract/build.gradle.kts
@@ -34,9 +34,7 @@ android {
 
 dependencies {
     implementation(libs.timber)
-    api(libs.play.integrity) // Use api since the interface exposes types from this library
-    implementation(libs.javax.inject) // For @Qualifier
-    // Removed Hilt compiler: ksp(libs.hilt.compiler)
-
-    api(libs.hilt.android)
+    api(libs.play.integrity)
+    implementation(libs.javax.inject)
+    implementation(libs.hilt.android)
 }

--- a/android/repository/impl/build.gradle.kts
+++ b/android/repository/impl/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     testImplementation(libs.kotlin.test)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.hilt.android.testing)
+    kspTest(libs.hilt.compiler)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/ui/main/build.gradle.kts
+++ b/android/ui/main/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.hilt.android.testing)
+    kspTest(libs.hilt.compiler)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/ui/nav/contract/build.gradle.kts
+++ b/android/ui/nav/contract/build.gradle.kts
@@ -33,5 +33,5 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.activity.ktx) // For ActivityResultContract
+    api(libs.androidx.activity.ktx)
 }


### PR DESCRIPTION
Refined Gradle dependencies for Android modules:
- Corrected api/implementation scopes for provider, ui-nav contracts.
- Added missing kspTest Hilt compilers for repository-impl and ui-main.
- Removed redundant transitive dependencies and unnecessary comments from build.gradle.kts files.

These changes improve build times and maintainability by ensuring modules only expose necessary APIs, correctly declare compile-time vs. runtime dependencies, and simplify build scripts. Verified by running clean, assembleDebug, testDebugUnitTest, and lintDebug tasks successfully.