### PR TITLE
Include Google Play Services info in Play Integrity verification

### DIFF
--- a/server/play_integrity/play_integrity.py
+++ b/server/play_integrity/play_integrity.py
@@ -121,10 +121,12 @@ def _store_verification_attempt(session_id, client_request_data, result, decoded
             # but ensures they are standardized.
             payload_to_store['device_info'] = client_request_data.get('device_info', {})
             payload_to_store['security_info'] = client_request_data.get('security_info', {})
+            payload_to_store['google_play_developer_service_info'] = client_request_data.get('googlePlayDeveloperServiceInfo', {})
         else:
             # If there's no client_request_data (e.g. very early error), ensure these fields exist.
             payload_to_store['device_info'] = {}
             payload_to_store['security_info'] = {}
+            payload_to_store['google_play_developer_service_info'] = {}
 
 
         entity_data = {
@@ -330,7 +332,8 @@ def verify_integrity_classic():
         response_payload = {
             "play_integrity_response": decoded_integrity_token_response,
             "device_info": data.get('device_info', {}),
-            "security_info": data.get('security_info', {})
+            "security_info": data.get('security_info', {}),
+            "google_play_developer_service_info": data.get('googlePlayDeveloperServiceInfo', {})
         }
         if result_status == RESULT_SUCCESS:
             return jsonify(response_payload), 200
@@ -466,7 +469,8 @@ def verify_integrity_standard():
         response_payload = {
             "play_integrity_response": decoded_integrity_token_response,
             "device_info": data.get('device_info', {}),
-            "security_info": data.get('security_info', {})
+            "security_info": data.get('security_info', {}),
+            "google_play_developer_service_info": data.get('googlePlayDeveloperServiceInfo', {})
         }
 
         if result_status == RESULT_SUCCESS:


### PR DESCRIPTION
- Modified server-side code to store and return Google Play Services information when verifying Play Integrity tokens.
- Confirmed that Android client-side code already supports sending this information.