### PR TITLE
Fix: Update ProGuard rules to prevent crash in release builds

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -23,3 +23,43 @@
 # Suppress R8 warning for kotlinx-serialization-common.pro
 # See https://youtrack.jetbrains.com/issue/KT-73255 and the build log for details.
 -dontwarn kotlinx.serialization.**
+
+# Keep Protocol Buffer generated classes and their members
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite {
+    <fields>;
+    <methods>;
+}
+
+# Keep classes related to Kotlinx Serialization
+# This includes classes annotated with @Serializable and their generated serializers.
+-keepattributes Serialization
+-keepclassmembers class * {
+    @kotlinx.serialization.Serializable <fields>;
+    @kotlinx.serialization.Serializable <methods>;
+    @kotlinx.serialization.Transient <fields>;
+    @kotlinx.serialization.Transient <methods>;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep class **$$serializer { *; }
+-keep class * implements kotlinx.serialization.KSerializer { *; }
+
+# Specifically keep the field name that caused the crash, across any class.
+# This is a broader rule, but might be necessary if the specific class is hard to pinpoint.
+# Use with caution and consider scoping it down if possible.
+-keepclassmembers class * {
+    long firstLaunchDatetime_;
+    # If it's a Kotlin property, its backing field might also be just the name
+    long firstLaunchDatetime;
+}
+
+# Keep names of classes that implement Parcelable, often used in Android.
+# While not directly indicated by the stack trace, it's a common source of issues with obfuscation.
+-keepnames class * implements android.os.Parcelable
+
+# Keep all public members of classes annotated with @Keep.
+# This allows developers to explicitly mark classes/members to be kept.
+-keep @androidx.annotation.Keep class * {*;}
+-keepclassmembers class * {
+    @androidx.annotation.Keep *;
+}


### PR DESCRIPTION
Added keep rules for Protocol Buffers and Kotlinx Serialization to prevent obfuscation issues with field names like 'firstLaunchDatetime_'. Also included general rules for Parcelable and @Keep annotations.