### PR TITLE
Remove "(Dev)" from app name and description

### DIFF
--- a/android/.idea/deploymentTargetSelector.xml
+++ b/android/.idea/deploymentTargetSelector.xml
@@ -5,9 +5,6 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="GooglePlayDeveloperServiceInfoProviderImplTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/android/docs/googleplay/app_name.txt
+++ b/android/docs/googleplay/app_name.txt
@@ -1,1 +1,1 @@
-    Integrity Check Tool (Dev)
+    Integrity Check Tool

--- a/android/docs/googleplay/full_description.txt
+++ b/android/docs/googleplay/full_description.txt
@@ -1,4 +1,4 @@
-「Integrity Check Tool (Dev)」は、Androidアプリ開発者向けの検証ツールです。自身のAndroid端末や開発中のアプリケーションで、端末信頼性検証機能（例: Play Integrity API）がどのように動作し、どのような結果を返すかを確認するために使用します。
+「Integrity Check Tool」は、Androidアプリ開発者向けの検証ツールです。自身のAndroid端末や開発中のアプリケーションで、端末信頼性検証機能（例: Play Integrity API）がどのように動作し、どのような結果を返すかを確認するために使用します。
 
 **主な目的と機能:**
 *   **端末信頼性検証の確認:** あなたのAndroidデバイスが、GoogleのPlay Integrity APIなどの検証メカニズムによってどのように評価されるか、その詳細な結果（デバイスの完全性、アプリのライセンス状況など）を表示します


### PR DESCRIPTION
The app name in `android/docs/googleplay/app_name.txt` was changed from "Integrity Check Tool (Dev)" to "Integrity Check Tool". Similarly, the "(Dev)" suffix was removed from the app name in the full description located in `android/docs/googleplay/full_description.txt`.