### PR TITLE
Fix: Prevent AgreementActivity from launching twice

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
@@ -108,7 +108,7 @@ fun DeviceIntegrityApp(
 
         // The outer if condition was removed as per user request.
         // The LaunchedEffect will now run based on isAgreed state regardless of isDebugBuild.
-        LaunchedEffect(isAgreed) {
+        LaunchedEffect(Unit) {
             if (!isAgreed) { // Avoid re-launching if already agreed during recomposition
                 val intent = agreementNavigator.newIntent(context)
                 agreementLauncher.launch(intent)


### PR DESCRIPTION
The AgreementActivity was sometimes launching twice because the LaunchedEffect in MainActivity was keyed to the `isAgreed` state. This could lead to a race condition where the activity was re-launched before the `isAgreed` state was updated after returning from the first launch.

Changed the LaunchedEffect key to `Unit` to ensure the agreement check and activity launch logic runs only once when the composable is first launched. The `isAgreed` state is checked within this effect to decide whether to launch the AgreementActivity.