### PR TITLE
Fix: Resolve ImportError in play_integrity service

### DIFF
--- a/server/play_integrity/Dockerfile
+++ b/server/play_integrity/Dockerfile
@@ -19,6 +19,7 @@ EXPOSE $PORT
 
 # Define environment variable
 ENV PORT 8080
+ENV PYTHONPATH /app
 
 # Run app.py when the container launches
-CMD exec gunicorn -b :$PORT play_integrity:app
+CMD exec gunicorn -b :$PORT server.play_integrity:app


### PR DESCRIPTION
Set PYTHONPATH and update Gunicorn command in Dockerfile to ensure play_integrity.py is loaded as part of the 'server' package, resolving a relative import error for '.utils'.

This addresses a 503 Service Unavailable error caused by the app failing to start.