### PR TITLE
Fix: Correct Gunicorn CMD in Play Integrity Dockerfile

### DIFF
--- a/server/play_integrity/Dockerfile
+++ b/server/play_integrity/Dockerfile
@@ -21,4 +21,4 @@ EXPOSE $PORT
 ENV PORT 8080
 
 # Run app.py when the container launches
-CMD exec gunicorn --pythonpath /app -b :$PORT server.play_integrity:app
+CMD exec gunicorn --pythonpath /app -b :$PORT play_integrity:app


### PR DESCRIPTION
Changed the Gunicorn command in server/play_integrity/Dockerfile from server.play_integrity:app to play_integrity:app.

This assumes the Docker build context is the server/play_integrity directory itself. If so, this change ensures Gunicorn can find the Flask application object named 'app' within play_integrity.py.