### PR TITLE
feat: Allow empty contentBinding for Play Integrity

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityUiState.kt
@@ -21,7 +21,7 @@ data class StandardPlayIntegrityUiState(
         get() = requestHashValue.isNotEmpty()
 
     val isRequestTokenButtonEnabled: Boolean
-        get() = !isLoading && contentBinding.isNotEmpty()
+        get() = !isLoading // Allow empty contentBinding
 
     val isVerifyTokenButtonEnabled: Boolean
         get() = !isLoading && integrityToken.isNotEmpty()

--- a/server/play_integrity/play_integrity.py
+++ b/server/play_integrity/play_integrity.py
@@ -394,11 +394,6 @@ def verify_integrity_standard():
             error_message_for_client = "Missing 'token' in request"
             _store_verification_attempt(session_id, data, result_status, decoded_integrity_token_response, "standard")
             return jsonify({"error": error_message_for_client}), 400
-        if not client_content_binding:
-            result_status = RESULT_FAILED
-            error_message_for_client = "Missing 'contentBinding' in request"
-            _store_verification_attempt(session_id, data, result_status, decoded_integrity_token_response, "standard")
-            return jsonify({"error": error_message_for_client}), 400
         if not session_id:
             result_status = RESULT_FAILED
             error_message_for_client = "Missing 'session_id' in request"


### PR DESCRIPTION
feat: Allow empty contentBinding for Play Integrity

Server:
- Modified `verify_integrity_standard` in `play_integrity.py` to allow requests with an empty `contentBinding` string. The check that previously rejected such requests has been removed.

Client (Android):
- Modified `StandardPlayIntegrityUiState.kt` to enable the 'Request Token' button even when the `contentBinding` input field is empty. This allows the user to initiate the Play Integrity flow without providing a content binding value.

Note: Android app testing (manual UI and automated via `./gradlew build`) could not be completed due to persistent command timeouts in the execution environment.