### PR TITLE
Refactor: Remove unnecessary string resources for license screen

### DIFF
--- a/android/ui/license/src/main/java/dev/keiji/deviceintegrity/ui/license/LicenseScreen.kt
+++ b/android/ui/license/src/main/java/dev/keiji/deviceintegrity/ui/license/LicenseScreen.kt
@@ -70,12 +70,12 @@ fun LicenseItem(
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = stringResource(R.string.license_item_license_label, licenseInfo.licenseName),
+                text = licenseInfo.licenseName,
                 style = MaterialTheme.typography.bodyMedium
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = stringResource(R.string.license_item_copyright_label, licenseInfo.copyrightHolder),
+                text = licenseInfo.copyrightHolder,
                 style = MaterialTheme.typography.bodyMedium
             )
             licenseInfo.licenseUrl?.also { licenseUrl ->

--- a/android/ui/license/src/main/res/values-ja/strings.xml
+++ b/android/ui/license/src/main/res/values-ja/strings.xml
@@ -1,6 +1,4 @@
 <resources>
     <string name="open_source_licenses">オープンソースライセンス</string>
     <string name="license_screen_close_button_description">閉じる</string>
-    <string name="license_item_license_label">ライセンス: %s</string>
-    <string name="license_item_copyright_label">著作権者: %s</string>
 </resources>

--- a/android/ui/license/src/main/res/values/strings.xml
+++ b/android/ui/license/src/main/res/values/strings.xml
@@ -1,6 +1,4 @@
 <resources>
     <string name="open_source_licenses">Open Source Licenses</string>
     <string name="license_screen_close_button_description">Close</string>
-    <string name="license_item_license_label">License: %s</string>
-    <string name="license_item_copyright_label">Copyright: %s</string>
 </resources>


### PR DESCRIPTION
Removes the `license_item_license_label` and `license_item_copyright_label` string resources.
The `LicenseScreen.kt` composable is updated to directly use the `licenseName` and `copyrightHolder` properties from the `LicenseInfo` object.

This change simplifies the code by removing indirection through string resources that were only formatting the display of existing data without providing translation or other benefits.