### PR TITLE
Fix: Use google_apis target for Android emulator in CI

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -98,6 +98,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 30
+          target: google_apis
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run Android Connected Tests


### PR DESCRIPTION
The emulator was failing to start in CI because the system image 'system-images;android-30;default;x86' could not be found.

This change updates the android-emulator-runner configuration to use 'target: google_apis', which makes it request the available system image 'system-images;android-30;google_apis;x86'.