### PR TITLE
Fix: Consolidate Android test execution into emulator runner

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -94,12 +94,18 @@ jobs:
           sudo udevadm trigger
           sudo usermod -a -G kvm $USER
 
-      - name: Create and run an Android emulator
+      - name: Run tests on emulator
         uses: reactivecircus/android-emulator-runner@v2
+        timeout-minutes: 20
         with:
           api-level: 30
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: Run Android Connected Tests
-        run: ./gradlew connectedAndroidTest
-        working-directory: ./android
+          target: google_apis
+          arch: x86 # Explicitly set, though it's default
+          # emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim # Using default options is often fine, can add if needed
+          disable-animations: true
+          working-directory: ./android # Important for gradle script path
+          script: |
+            echo "Listing connected devices..."
+            adb devices
+            echo "Running Android connected tests..."
+            ./gradlew connectedAndroidTest


### PR DESCRIPTION
Previously, Android connected tests were run in a separate step after the android-emulator-runner action had completed. This meant the emulator was likely no longer available, leading to 'No connected devices' errors.

This change consolidates the test execution into the `script` parameter of the `android-emulator-runner` action. It also adds an `adb devices` command before running tests for better debugging and increases the timeout for the emulator step.