### PR TITLE
Refactor: Change applicationIdSuffix from .debug to .develop

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -94,7 +94,7 @@ android {
             // versionNameSuffix is inherited from release.
         }
         debug {
-            applicationIdSuffix = ".debug"
+            applicationIdSuffix = ".develop"
             versionNameSuffix = "-$commitHash"
         }
     }

--- a/android/app/src/androidTest/java/dev/keiji/deviceintegrity/ExampleInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/dev/keiji/deviceintegrity/ExampleInstrumentedTest.kt
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("dev.keiji.deviceintegrity", appContext.packageName)
+        assertEquals("dev.keiji.deviceintegrity.develop", appContext.packageName)
     }
 }


### PR DESCRIPTION
- Updated the `applicationIdSuffix` for the debug build type from ".debug" to ".develop" in `android/app/build.gradle.kts`.
- Removed a session file specific to the Kotlin compiler.