### PR TITLE
Refactor bottom navigation to use MainUiState

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/AppScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/AppScreen.kt
@@ -13,9 +13,3 @@ sealed class AppScreen(
     object KeyAttestation : AppScreen("key_attestation", R.string.app_screen_key_attestation_label, R.drawable.ic_key)
     object Menu : AppScreen("menu", R.string.app_screen_menu_label, R.drawable.ic_menu)
 }
-
-val bottomNavigationItems = listOf(
-    AppScreen.PlayIntegrity,
-    AppScreen.KeyAttestation,
-    AppScreen.Menu
-)

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -89,6 +90,7 @@ fun DeviceIntegrityApp(
         val navController = rememberNavController()
         val context = LocalContext.current
         val isAgreed by mainViewModel.isAgreed.collectAsStateWithLifecycle()
+        val uiState by mainViewModel.uiState.collectAsState()
 
         val agreementLauncher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.StartActivityForResult()
@@ -115,13 +117,9 @@ fun DeviceIntegrityApp(
                 NavigationBar {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val currentDestination = navBackStackEntry?.destination
-                    bottomNavigationItems
-                        .filter { screen ->
-                            screen != AppScreen.KeyAttestation || Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
-                        }
-                        .forEach { screen ->
-                            NavigationBarItem(
-                                icon = {
+                    uiState.bottomNavigationItems.forEach { screen ->
+                        NavigationBarItem(
+                            icon = {
                                 Icon(
                                     painter = androidx.compose.ui.res.painterResource(id = screen.icon),
                                     contentDescription = stringResource(id = screen.label)

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainUiState.kt
@@ -1,0 +1,5 @@
+package dev.keiji.deviceintegrity.ui.main
+
+data class MainUiState(
+    val bottomNavigationItems: List<AppScreen> = emptyList()
+)

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainViewModel.kt
@@ -1,11 +1,14 @@
 package dev.keiji.deviceintegrity.ui.main
 
+import android.os.Build
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.keiji.deviceintegrity.repository.contract.PreferencesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -22,6 +25,9 @@ class MainViewModel @Inject constructor(
 
     val isAgreed: StateFlow<Boolean> = savedStateHandle.getStateFlow(KEY_IS_AGREED, false)
 
+    private val _uiState = MutableStateFlow(MainUiState())
+    val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
+
     init {
         viewModelScope.launch {
             val firstLaunch = preferencesRepository.firstLaunchDatetime.firstOrNull()
@@ -29,6 +35,20 @@ class MainViewModel @Inject constructor(
                 preferencesRepository.saveFirstLaunchDatetime(System.currentTimeMillis())
             }
         }
+
+        val availableScreens = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            listOf(
+                AppScreen.PlayIntegrity,
+                AppScreen.KeyAttestation,
+                AppScreen.Menu
+            )
+        } else {
+            listOf(
+                AppScreen.PlayIntegrity,
+                AppScreen.Menu
+            )
+        }
+        _uiState.value = MainUiState(bottomNavigationItems = availableScreens)
     }
 
     fun setAgreed(agreed: Boolean) {


### PR DESCRIPTION
- Created MainUiState to hold bottomNavigationItems.
- Modified MainViewModel to provide MainUiState with conditional bottomNavigationItems based on Android version.
- Updated MainActivity to consume MainUiState for bottom navigation.
- Removed global bottomNavigationItems from AppScreen.kt.