### PR TITLE
Implement Key Attestation flow in ViewModel

### DIFF
--- a/android/.idea/deploymentTargetSelector.xml
+++ b/android/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,9 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="KeyPairRepositoryImplTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -12,6 +12,9 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/api" />
             <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/crypto" />
+            <option value="$PROJECT_DIR$/crypto/contract" />
+            <option value="$PROJECT_DIR$/crypto/impl" />
             <option value="$PROJECT_DIR$/provider" />
             <option value="$PROJECT_DIR$/provider/contract" />
             <option value="$PROJECT_DIR$/provider/impl" />

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
@@ -1,9 +1,5 @@
 package dev.keiji.deviceintegrity.api.keyattestation
 
-import dev.keiji.deviceintegrity.api.keyattestation.PrepareRequest
-import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
-import dev.keiji.deviceintegrity.api.keyattestation.VerifyEcRequest
-import dev.keiji.deviceintegrity.api.keyattestation.VerifyEcResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcRequest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class VerifyEcRequest(
     val sessionId: String,
-    val signedDataBase64Encoded: String, // Base64 Encoded
-    val nonceBBase64Encoded: String, // Base64 Encoded
-    val certificateChainBase64Encoded: List<String> // List of Base64 Encoded strings
+    val signedDataBase64UrlEncoded: String, // Base64URL Encoded
+    val nonceBBase64UrlEncoded: String, // Base64URL Encoded
+    val certificateChainBase64UrlEncoded: List<String> // List of Base64URL Encoded strings
 )

--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/CryptoModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/CryptoModule.kt
@@ -10,15 +10,19 @@ import dev.keiji.deviceintegrity.crypto.contract.Verifier
 import dev.keiji.deviceintegrity.crypto.impl.EcSignerImpl
 import dev.keiji.deviceintegrity.crypto.impl.EcVerifierImpl
 
+import javax.inject.Singleton
+
 @Module
 @InstallIn(SingletonComponent::class)
-object CryptoModule {
+class CryptoModule {
 
     @EC
     @Provides
+    @Singleton // Added @Singleton here as well
     fun provideEcSigner(): Signer = EcSignerImpl()
 
     @EC
     @Provides
+    @Singleton // Added @Singleton here as well
     fun provideEcVerifier(): Verifier = EcVerifierImpl()
 }

--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/CryptoModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/CryptoModule.kt
@@ -4,25 +4,24 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import dev.keiji.deviceintegrity.di.qualifier.EC
 import dev.keiji.deviceintegrity.crypto.contract.Signer
 import dev.keiji.deviceintegrity.crypto.contract.Verifier
+import dev.keiji.deviceintegrity.crypto.contract.qualifier.EC
 import dev.keiji.deviceintegrity.crypto.impl.EcSignerImpl
 import dev.keiji.deviceintegrity.crypto.impl.EcVerifierImpl
-
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-class CryptoModule {
+object CryptoModule {
 
     @EC
     @Provides
-    @Singleton // Added @Singleton here as well
+    @Singleton
     fun provideEcSigner(): Signer = EcSignerImpl()
 
     @EC
     @Provides
-    @Singleton // Added @Singleton here as well
+    @Singleton
     fun provideEcVerifier(): Verifier = EcVerifierImpl()
 }

--- a/android/crypto/contract/build.gradle.kts
+++ b/android/crypto/contract/build.gradle.kts
@@ -31,4 +31,5 @@ android {
 }
 
 dependencies {
+    implementation(libs.javax.inject)
 }

--- a/android/crypto/contract/src/main/java/dev/keiji/deviceintegrity/crypto/contract/qualifier/EC.kt
+++ b/android/crypto/contract/src/main/java/dev/keiji/deviceintegrity/crypto/contract/qualifier/EC.kt
@@ -1,4 +1,4 @@
-package dev.keiji.deviceintegrity.di.qualifier
+package dev.keiji.deviceintegrity.crypto.contract.qualifier
 
 import javax.inject.Qualifier
 

--- a/android/crypto/contract/src/main/java/dev/keiji/deviceintegrity/crypto/contract/qualifier/ECDH.kt
+++ b/android/crypto/contract/src/main/java/dev/keiji/deviceintegrity/crypto/contract/qualifier/ECDH.kt
@@ -1,4 +1,4 @@
-package dev.keiji.deviceintegrity.di.qualifier
+package dev.keiji.deviceintegrity.crypto.contract.qualifier
 
 import javax.inject.Qualifier
 

--- a/android/crypto/contract/src/main/java/dev/keiji/deviceintegrity/crypto/contract/qualifier/RSA.kt
+++ b/android/crypto/contract/src/main/java/dev/keiji/deviceintegrity/crypto/contract/qualifier/RSA.kt
@@ -1,4 +1,4 @@
-package dev.keiji.deviceintegrity.di.qualifier
+package dev.keiji.deviceintegrity.crypto.contract.qualifier
 
 import javax.inject.Qualifier
 

--- a/android/crypto/impl/build.gradle.kts
+++ b/android/crypto/impl/build.gradle.kts
@@ -35,8 +35,7 @@ android {
 dependencies {
     api(project(":crypto:contract"))
 
-    // implementation(libs.hilt.android) // Hilt dependency no longer needed here
-    // ksp(libs.hilt.compiler) // Hilt ksp no longer needed here
+    implementation(libs.javax.inject)
 
     testImplementation(libs.junit)
 }

--- a/android/crypto/impl/build.gradle.kts
+++ b/android/crypto/impl/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.hilt.android.testing)
+    kspTest(libs.hilt.compiler)
 
     androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/android/crypto/impl/build.gradle.kts
+++ b/android/crypto/impl/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    // alias(libs.plugins.ksp) // ksp no longer needed if no Hilt modules here
+    // alias(libs.plugins.hilt) // Hilt plugin no longer needed here
 }
 
 android {
@@ -32,6 +34,9 @@ android {
 
 dependencies {
     api(project(":crypto:contract"))
+
+    // implementation(libs.hilt.android) // Hilt dependency no longer needed here
+    // ksp(libs.hilt.compiler) // Hilt ksp no longer needed here
 
     testImplementation(libs.junit)
 }

--- a/android/crypto/impl/build.gradle.kts
+++ b/android/crypto/impl/build.gradle.kts
@@ -38,4 +38,6 @@ dependencies {
     implementation(libs.javax.inject)
 
     testImplementation(libs.junit)
+
+    androidTestImplementation(libs.androidx.junit)
 }

--- a/android/crypto/impl/src/main/java/dev/keiji/deviceintegrity/crypto/impl/EcSignerImpl.kt
+++ b/android/crypto/impl/src/main/java/dev/keiji/deviceintegrity/crypto/impl/EcSignerImpl.kt
@@ -3,8 +3,9 @@ package dev.keiji.deviceintegrity.crypto.impl
 import dev.keiji.deviceintegrity.crypto.contract.Signer
 import java.security.PrivateKey
 import java.security.Signature
+import javax.inject.Inject
 
-class EcSignerImpl : Signer {
+class EcSignerImpl @Inject constructor() : Signer {
     companion object {
         private const val ALGORITHM_SHA256_WITH_ECDSA = "SHA256withECDSA"
     }

--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyPairData.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyPairData.kt
@@ -1,10 +1,12 @@
 package dev.keiji.deviceintegrity.repository.contract
 
+import java.security.KeyPair
 import java.security.cert.X509Certificate
 
 data class KeyPairData(
     val keyAlias: String,
-    val certificates: Array<X509Certificate>
+    val certificates: Array<X509Certificate>,
+    val keyPair: KeyPair? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -14,6 +16,7 @@ data class KeyPairData(
 
         if (keyAlias != other.keyAlias) return false
         if (!certificates.contentEquals(other.certificates)) return false
+        if (keyPair != other.keyPair) return false
 
         return true
     }
@@ -21,6 +24,7 @@ data class KeyPairData(
     override fun hashCode(): Int {
         var result = keyAlias.hashCode()
         result = 31 * result + certificates.contentHashCode()
+        result = 31 * result + (keyPair?.hashCode() ?: 0)
         return result
     }
 }

--- a/android/repository/impl/src/androidTest/java/dev/keiji/deviceintegrity/repository/impl/KeyPairRepositoryImplTest.kt
+++ b/android/repository/impl/src/androidTest/java/dev/keiji/deviceintegrity/repository/impl/KeyPairRepositoryImplTest.kt
@@ -96,8 +96,10 @@ class KeyPairRepositoryImplTest {
         val result = keyPairRepository.getKeyPair(alias)
 
         assertNotNull(result)
-        assertEquals(expectedKeyPair.public, result?.public)
-        assertEquals(expectedKeyPair.private, result?.private)
+        assertEquals(
+            expectedKeyPair.public.encoded.toHexString(),
+            result?.public?.encoded?.toHexString()
+        )
     }
 
     @Test

--- a/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyPairRepositoryImpl.kt
+++ b/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyPairRepositoryImpl.kt
@@ -98,7 +98,7 @@ class KeyPairRepositoryImpl(
             specBuilder.setAttestationChallenge(challenge)
 
             keyPairGenerator.initialize(specBuilder.build())
-            keyPairGenerator.generateKeyPair()
+            val generatedKeyPair = keyPairGenerator.generateKeyPair() // Store the generated KeyPair
 
             val certificateChain = keyStore.getCertificateChain(localKeyAlias)
 
@@ -122,9 +122,15 @@ class KeyPairRepositoryImpl(
                 throw IllegalStateException("X509Certificate chain is empty for alias: $localKeyAlias")
             }
 
+            // Retrieve the KeyPair to include in KeyPairData.
+            // The KeyPairGenerator already returns the KeyPair, so we can use that.
+            // If we needed to fetch it again (e.g. if KeyPairGenerator didn't return it),
+            // we could use the internal getKeyPair(localKeyAlias) method,
+            // but it's better to use the directly generated one.
             return@withContext KeyPairData(
                 keyAlias = localKeyAlias,
-                certificates = x509Certificates
+                certificates = x509Certificates,
+                keyPair = generatedKeyPair // Include the generated KeyPair
             )
         }
 }

--- a/android/ui/main/build.gradle.kts
+++ b/android/ui/main/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(project(":provider:contract"))
     implementation(project(":repository:contract"))
     implementation(project(":ui:nav:contract"))
+    implementation(project(":crypto:contract"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -1,8 +1,12 @@
 package dev.keiji.deviceintegrity.ui.main.keyattestation
 
+import dev.keiji.deviceintegrity.repository.contract.KeyPairData
+
 data class KeyAttestationUiState(
     val nonce: String = "",
     val challenge: String = "",
     val selectedKeyType: String = "EC", // Default to EC or the first option
-    val status: String = ""
+    val status: String = "",
+    val sessionId: String? = null,
+    val generatedKeyPairData: KeyPairData? = null
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -2,24 +2,24 @@ package dev.keiji.deviceintegrity.ui.main.keyattestation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import java.util.Base64 // Replaced android.util.Base64
+import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.keiji.deviceintegrity.api.keyattestation.KeyAttestationVerifyApiClient
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareRequest
 import dev.keiji.deviceintegrity.api.keyattestation.VerifyEcRequest
 import dev.keiji.deviceintegrity.crypto.contract.Signer
+import dev.keiji.deviceintegrity.crypto.contract.qualifier.EC
 import dev.keiji.deviceintegrity.repository.contract.KeyPairRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch // Ensure this is imported
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.security.SecureRandom
 import java.util.UUID
 import javax.inject.Inject
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dev.keiji.deviceintegrity.di.qualifier.EC
+import kotlin.io.encoding.Base64
 
 @HiltViewModel
 class KeyAttestationViewModel @Inject constructor(
@@ -49,7 +49,13 @@ class KeyAttestationViewModel @Inject constructor(
     // Action to fetch Nonce/Challenge
     fun fetchNonceChallenge() {
         viewModelScope.launch {
-            _uiState.update { it.copy(status = "Fetching Nonce/Challenge...", nonce = "", challenge = "") }
+            _uiState.update {
+                it.copy(
+                    status = "Fetching Nonce/Challenge...",
+                    nonce = "",
+                    challenge = ""
+                )
+            }
             try {
                 val newSessionId = UUID.randomUUID().toString()
                 _uiState.update { it.copy(sessionId = newSessionId) }
@@ -83,7 +89,12 @@ class KeyAttestationViewModel @Inject constructor(
     // Action to generate KeyPair
     fun generateKeyPair() {
         viewModelScope.launch {
-            _uiState.update { it.copy(status = "Generating KeyPair...", generatedKeyPairData = null) }
+            _uiState.update {
+                it.copy(
+                    status = "Generating KeyPair...",
+                    generatedKeyPairData = null
+                )
+            }
 
             val currentChallenge = uiState.value.challenge
             if (currentChallenge.isEmpty()) {
@@ -95,7 +106,7 @@ class KeyAttestationViewModel @Inject constructor(
                 // Decode the challenge from Base64Url
                 // URL_SAFE is used because the server sends it as Base64UrlEncoded.
                 val decodedChallenge = withContext(Dispatchers.Default) {
-                    Base64.getUrlDecoder().decode(currentChallenge)
+                    Base64.UrlSafe.decode(currentChallenge)
                 }
 
                 // Perform key generation on IO dispatcher
@@ -129,7 +140,8 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update { it.copy(status = "SessionId is missing. Fetch Nonce/Challenge first.") }
                 return@launch
             }
-            if (currentKeyPairData?.keyPair == null) {
+            val keyPair = currentKeyPairData?.keyPair
+            if (keyPair == null) {
                 _uiState.update { it.copy(status = "KeyPair is not generated yet.") }
                 return@launch
             }
@@ -146,20 +158,21 @@ class KeyAttestationViewModel @Inject constructor(
                     SecureRandom().nextBytes(nonceB)
 
                     // Server nonce is Base64URL Encoded
-                    val decodedServerNonce = Base64.getUrlDecoder().decode(serverNonceB64Url)
+                    val decodedServerNonce = Base64.UrlSafe.decode(serverNonceB64Url)
                     val dataToSign = decodedServerNonce + nonceB
 
                     // 2. Signing
-                    val privateKey = currentKeyPairData.keyPair.private
+                    val privateKey = keyPair.private
                     val signatureData = signer.sign(dataToSign, privateKey)
 
                     // 3. Encoding for Request (Base64URL as per task, without padding)
-                    val urlSafeEncoder = Base64.getUrlEncoder().withoutPadding()
-                    val signedDataBase64UrlEncoded = urlSafeEncoder.encodeToString(signatureData)
-                    val nonceBBase64UrlEncoded = urlSafeEncoder.encodeToString(nonceB)
-                    val certificateChainBase64UrlEncoded = currentKeyPairData.certificates.map { cert ->
-                        urlSafeEncoder.encodeToString(cert.encoded)
-                    }
+                    val urlSafeEncoder = Base64.UrlSafe
+                    val signedDataBase64UrlEncoded = urlSafeEncoder.encode(signatureData)
+                    val nonceBBase64UrlEncoded = urlSafeEncoder.encode(nonceB)
+                    val certificateChainBase64UrlEncoded =
+                        currentKeyPairData.certificates.map { cert ->
+                            urlSafeEncoder.encode(cert.encoded)
+                        }
 
                     // 4. API Call
                     val request = VerifyEcRequest(

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -1,14 +1,28 @@
 package dev.keiji.deviceintegrity.ui.main.keyattestation
 
+import android.util.Base64
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dev.keiji.deviceintegrity.api.keyattestation.KeyAttestationVerifyApiClient
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareRequest
+import dev.keiji.deviceintegrity.api.keyattestation.VerifyEcRequest
+import dev.keiji.deviceintegrity.crypto.contract.Signer
+import dev.keiji.deviceintegrity.repository.contract.KeyPairRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch // Ensure this is imported
+import kotlinx.coroutines.withContext
+import java.security.SecureRandom
+import java.util.UUID
 
-class KeyAttestationViewModel : ViewModel() {
+class KeyAttestationViewModel(
+    private val keyPairRepository: KeyPairRepository,
+    private val keyAttestationVerifyApiClient: KeyAttestationVerifyApiClient,
+    private val signer: Signer
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(KeyAttestationUiState())
     val uiState: StateFlow<KeyAttestationUiState> = _uiState.asStateFlow()
@@ -31,15 +45,33 @@ class KeyAttestationViewModel : ViewModel() {
     // Action to fetch Nonce/Challenge
     fun fetchNonceChallenge() {
         viewModelScope.launch {
-            _uiState.update { it.copy(status = "Fetching Nonce/Challenge...") }
-            // Simulate network call or actual logic
-            kotlinx.coroutines.delay(1000) // Simulate delay
-            _uiState.update {
-                it.copy(
-                    nonce = "SAMPLE_NONCE_FROM_SERVER_123",
-                    challenge = "SAMPLE_CHALLENGE_FROM_SERVER_ABC",
-                    status = "Nonce/Challenge fetched."
-                )
+            _uiState.update { it.copy(status = "Fetching Nonce/Challenge...", nonce = "", challenge = "") }
+            try {
+                val newSessionId = UUID.randomUUID().toString()
+                _uiState.update { it.copy(sessionId = newSessionId) }
+
+                val request = PrepareRequest(sessionId = newSessionId)
+
+                // Perform network call on IO dispatcher
+                val response = withContext(Dispatchers.IO) {
+                    keyAttestationVerifyApiClient.prepare(request)
+                }
+
+                _uiState.update {
+                    it.copy(
+                        nonce = response.nonceBase64UrlEncoded,
+                        challenge = response.challengeBase64UrlEncoded,
+                        status = "Nonce/Challenge fetched successfully."
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        status = "Failed to fetch Nonce/Challenge: ${e.message}",
+                        sessionId = null // Clear sessionId on failure
+                    )
+                }
+                // Optionally log the exception e.g. Timber.e(e, "fetchNonceChallenge failed")
             }
         }
     }
@@ -47,10 +79,37 @@ class KeyAttestationViewModel : ViewModel() {
     // Action to generate KeyPair
     fun generateKeyPair() {
         viewModelScope.launch {
-            _uiState.update { it.copy(status = "Generating KeyPair...") }
-            // Simulate key generation
-            kotlinx.coroutines.delay(1000) // Simulate delay
-            _uiState.update { it.copy(status = "KeyPair Generated.") }
+            _uiState.update { it.copy(status = "Generating KeyPair...", generatedKeyPairData = null) }
+
+            val currentChallenge = uiState.value.challenge
+            if (currentChallenge.isEmpty()) {
+                _uiState.update { it.copy(status = "Challenge is not available. Fetch Nonce/Challenge first.") }
+                return@launch
+            }
+
+            try {
+                // Decode the challenge from Base64Url
+                // Using NO_WRAP as KeyGenParameterSpec.Builder#setAttestationChallenge expects the raw challenge bytes.
+                // URL_SAFE is used because the server sends it as Base64UrlEncoded.
+                val decodedChallenge = withContext(Dispatchers.Default) {
+                    Base64.decode(currentChallenge, Base64.URL_SAFE or Base64.NO_WRAP)
+                }
+
+                // Perform key generation on IO dispatcher
+                val keyPairDataResult = withContext(Dispatchers.IO) {
+                    keyPairRepository.generateKeyPair(decodedChallenge)
+                }
+
+                _uiState.update {
+                    it.copy(
+                        generatedKeyPairData = keyPairDataResult,
+                        status = "KeyPair generated successfully. Alias: ${keyPairDataResult.keyAlias}"
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(status = "Failed to generate KeyPair: ${e.message}") }
+                // Optionally log the exception
+            }
         }
     }
 
@@ -58,14 +117,70 @@ class KeyAttestationViewModel : ViewModel() {
     fun requestVerifyKeyAttestation() {
         viewModelScope.launch {
             _uiState.update { it.copy(status = "Verifying KeyAttestation...") }
-            // Simulate verification
-            kotlinx.coroutines.delay(1500) // Simulate delay
-            // Simulate success/failure
-            val success = kotlin.random.Random.nextBoolean()
-            if (success) {
-                _uiState.update { it.copy(status = "Verification Complete.") }
-            } else {
-                _uiState.update { it.copy(status = "Verification Failed.") }
+
+            val currentSessionId = uiState.value.sessionId
+            val currentKeyPairData = uiState.value.generatedKeyPairData
+            val serverNonceB64Url = uiState.value.nonce // This is server's nonce from prepare step
+
+            if (currentSessionId == null) {
+                _uiState.update { it.copy(status = "SessionId is missing. Fetch Nonce/Challenge first.") }
+                return@launch
+            }
+            if (currentKeyPairData?.keyPair == null) {
+                _uiState.update { it.copy(status = "KeyPair is not generated yet.") }
+                return@launch
+            }
+            if (serverNonceB64Url.isEmpty()) {
+                _uiState.update { it.copy(status = "Server Nonce is missing. Fetch Nonce/Challenge first.") }
+                return@launch
+            }
+
+            try {
+                // Perform encoding, signing, and network call on appropriate dispatchers
+                val response = withContext(Dispatchers.IO) {
+                    // 1. Nonce Handling
+                    val nonceB = ByteArray(32)
+                    SecureRandom().nextBytes(nonceB)
+
+                    // Server nonce is Base64URL Encoded
+                    val decodedServerNonce = Base64.decode(serverNonceB64Url, Base64.URL_SAFE or Base64.NO_WRAP)
+                    val dataToSign = decodedServerNonce + nonceB
+
+                    // 2. Signing
+                    val privateKey = currentKeyPairData.keyPair.private
+                    val signatureData = signer.sign(dataToSign, privateKey)
+
+                    // 3. Encoding for Request (Base64URL as per task)
+                    val base64Flags = Base64.URL_SAFE or Base64.NO_WRAP
+                    val signedDataBase64UrlEncoded = Base64.encodeToString(signatureData, base64Flags)
+                    val nonceBBase64UrlEncoded = Base64.encodeToString(nonceB, base64Flags)
+                    val certificateChainBase64UrlEncoded = currentKeyPairData.certificates.map { cert ->
+                        Base64.encodeToString(cert.encoded, base64Flags)
+                    }
+
+                    // 4. API Call
+                    val request = VerifyEcRequest(
+                        sessionId = currentSessionId,
+                        signedDataBase64Encoded = signedDataBase64UrlEncoded, // Field name is Base64Encoded, but task requires UrlEncoded
+                        nonceBBase64Encoded = nonceBBase64UrlEncoded, // Field name is Base64Encoded, but task requires UrlEncoded
+                        certificateChainBase64Encoded = certificateChainBase64UrlEncoded // Field name is Base64Encoded, but task requires UrlEncoded
+                    )
+                    keyAttestationVerifyApiClient.verifyEc(request)
+                }
+
+                if (response.isVerified) {
+                    _uiState.update {
+                        it.copy(status = "Verification successful. Session: ${response.sessionId}, Verified: ${response.isVerified}")
+                    }
+                } else {
+                    _uiState.update {
+                        it.copy(status = "Verification failed. Reason: ${response.reason ?: "Unknown"}")
+                    }
+                }
+
+            } catch (e: Exception) {
+                _uiState.update { it.copy(status = "Failed to verify KeyAttestation: ${e.message}") }
+                // Optionally log the exception
             }
         }
     }


### PR DESCRIPTION
- Modified KeyPairData to include the KeyPair object.
- Updated KeyPairRepository to return the KeyPair in KeyPairData.
- Enhanced KeyAttestationUiState to hold sessionId and generated KeyPairData.
- Implemented fetching nonce/challenge from the server, including sessionId generation.
- Implemented KeyPair generation using the server's challenge.
- Implemented Key Attestation verification: generating nonceB, signing data, Base64Url encoding, and calling the verification API.
- Added constructor dependencies to KeyAttestationViewModel for necessary services and repositories.
- Ensured network operations are on background dispatchers and included basic error handling.