### PR TITLE
Add Hilt configuration to crypto:impl module

### DIFF
--- a/android/crypto/impl/build.gradle.kts
+++ b/android/crypto/impl/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    // alias(libs.plugins.ksp) // ksp no longer needed if no Hilt modules here
-    // alias(libs.plugins.hilt) // Hilt plugin no longer needed here
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
 }
 
 android {
@@ -36,6 +36,9 @@ dependencies {
     api(project(":crypto:contract"))
 
     implementation(libs.javax.inject)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
 }


### PR DESCRIPTION
This commit adds the necessary Hilt plugin and dependencies to the `android/crypto/impl/build.gradle.kts` file as requested in the PR review.