### PR TITLE
Refactor: Use enum for CryptoAlgorithm in KeyAttestation

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/CryptoAlgorithm.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/CryptoAlgorithm.kt
@@ -1,0 +1,7 @@
+package dev.keiji.deviceintegrity.ui.main.keyattestation
+
+enum class CryptoAlgorithm(val value: String, val label: String) {
+    EC("EC", "Elliptic Curve"),
+    ECDH("ECDH", "Elliptic Curve Diffie-Hellman"),
+    RSA("RSA", "RSA")
+}

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -33,14 +33,14 @@ import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 @Composable
 fun KeyAttestationScreen(
     uiState: KeyAttestationUiState,
-    onSelectedKeyTypeChange: (String) -> Unit,
+    onSelectedKeyTypeChange: (CryptoAlgorithm) -> Unit,
     onFetchNonceChallenge: () -> Unit,
     onGenerateKeyPair: () -> Unit,
     onRequestVerifyKeyAttestation: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
     var keyTypeExpanded by remember { mutableStateOf(false) }
-    val keyTypes = listOf("EC", "ECDH", "RSA") // TODO: Move to ViewModel or constants
+    val keyTypes = CryptoAlgorithm.values().toList()
 
     Column(
         modifier = Modifier
@@ -77,7 +77,7 @@ fun KeyAttestationScreen(
                 onExpandedChange = { keyTypeExpanded = !keyTypeExpanded }
             ) {
                 TextField(
-                    value = uiState.selectedKeyType,
+                    value = uiState.selectedKeyType.label,
                     onValueChange = {}, // This remains empty as direct text input is not intended
                     readOnly = true,
                     label = { Text("Key Pair Type") },
@@ -91,11 +91,11 @@ fun KeyAttestationScreen(
                     expanded = keyTypeExpanded,
                     onDismissRequest = { keyTypeExpanded = false }
                 ) {
-                    keyTypes.forEach { selectionOption ->
+                    keyTypes.forEach { algorithm ->
                         DropdownMenuItem(
-                            text = { Text(selectionOption) },
+                            text = { Text(algorithm.label) },
                             onClick = {
-                                onSelectedKeyTypeChange(selectionOption)
+                                onSelectedKeyTypeChange(algorithm)
                                 keyTypeExpanded = false
                             }
                         )
@@ -142,10 +142,10 @@ private fun KeyAttestationScreenPreview() {
         uiState = KeyAttestationUiState(
             nonce = "PREVIEW_NONCE_67890",
             challenge = "PREVIEW_CHALLENGE_ABCDE",
-            selectedKeyType = "RSA",
+            selectedKeyType = CryptoAlgorithm.RSA,
             status = "Previewing KeyAttestation Screen..."
         ),
-        onSelectedKeyTypeChange = { System.out.println("Preview: Key type changed to $it") },
+        onSelectedKeyTypeChange = { System.out.println("Preview: Key type changed to ${it.label}") },
         onFetchNonceChallenge = { System.out.println("Preview: Fetch Nonce/Challenge clicked") },
         onGenerateKeyPair = { System.out.println("Preview: Generate KeyPair clicked") },
         onRequestVerifyKeyAttestation = { System.out.println("Preview: Request Verify KeyAttestation clicked") }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -5,7 +5,7 @@ import dev.keiji.deviceintegrity.repository.contract.KeyPairData
 data class KeyAttestationUiState(
     val nonce: String = "",
     val challenge: String = "",
-    val selectedKeyType: String = "EC", // Default to EC or the first option
+    val selectedKeyType: CryptoAlgorithm = CryptoAlgorithm.EC, // Default to EC
     val status: String = "",
     val sessionId: String? = null,
     val generatedKeyPairData: KeyPairData? = null

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -42,7 +42,7 @@ class KeyAttestationViewModel @Inject constructor(
     }
 
     // Event handler for Selected Key Type change
-    fun onSelectedKeyTypeChange(newKeyType: String) {
+    fun onSelectedKeyTypeChange(newKeyType: CryptoAlgorithm) {
         _uiState.update { it.copy(selectedKeyType = newKeyType) }
     }
 


### PR DESCRIPTION
 - close #272 

Replaced string-based cryptographic algorithm selection in KeyAttestation with a new CryptoAlgorithm enum.

- Created CryptoAlgorithm.kt with EC, ECDH, and RSA algorithms, including string values and display labels.
- Updated KeyAttestationUiState to use CryptoAlgorithm for selectedKeyType.
- Modified KeyAttestationViewModel to handle CryptoAlgorithm type.
- Updated KeyAttestationScreen to use CryptoAlgorithm for dropdown menu and display labels.