### PR TITLE
Refactor Cloud Run deployment workflows

### DIFF
--- a/.github/workflows/cloud_run_deploy.yml
+++ b/.github/workflows/cloud_run_deploy.yml
@@ -1,11 +1,8 @@
 name: Deploy to Cloud Run
 
 on:
-  push:
-    branches:
-      - release/server
-    paths:
-      - 'server/**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/cloud_run_deploy.yml
+++ b/.github/workflows/cloud_run_deploy.yml
@@ -1,8 +1,11 @@
 name: Deploy to Cloud Run
 
 on:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  push:
+    branches:
+      - release/server
+    paths:
+      - 'server/**'
 
 env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/cloud_run_deploy_develop.yml
+++ b/.github/workflows/cloud_run_deploy_develop.yml
@@ -1,12 +1,6 @@
 name: Deploy to Cloud Run (Develop Server)
 
 on:
-  push:
-    branches:
-      - develop/server
-    paths:
-      - 'server/**'
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
- `.github/workflows/cloud_run_deploy_develop.yml`:
  - Removed push trigger.
  - Enabled `workflow_dispatch` for manual deployment.
  - This workflow can be used to deploy any branch manually, including `main`,
    by specifying the desired branch/ref when running the workflow.

- `.github/workflows/cloud_run_deploy.yml`:
  - Restored to its original state.
  - Automatically deploys on push to `release/server` branch.