### PR TITLE
Convert Cloud Run workflows to manual dispatch

### DIFF
--- a/.github/workflows/cloud_run_deploy.yml
+++ b/.github/workflows/cloud_run_deploy.yml
@@ -1,11 +1,8 @@
 name: Deploy to Cloud Run
 
 on:
-  push:
-    branches:
-      - release/server
-    paths:
-      - 'server/**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/cloud_run_deploy_develop.yml
+++ b/.github/workflows/cloud_run_deploy_develop.yml
@@ -1,12 +1,6 @@
 name: Deploy to Cloud Run (Develop Server)
 
 on:
-  push:
-    branches:
-      - develop/server
-    paths:
-      - 'server/**'
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
- `.github/workflows/cloud_run_deploy_develop.yml`:
  - Removed push trigger.
  - Enabled `workflow_dispatch` for manual deployment.

- `.github/workflows/cloud_run_deploy.yml`:
  - Removed push trigger.
  - Enabled `workflow_dispatch` for manual deployment.

Both workflows now only support manual triggering via the GitHub Actions UI. This allows for manual deployment of any specified branch/ref, including `main`.