### PR TITLE
Refactor: Update JSON keys to simple snake_case, keep field name suff…

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareRequest.kt
@@ -1,8 +1,10 @@
 package dev.keiji.deviceintegrity.api.keyattestation
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class PrepareRequest(
+    @SerialName("session_id")
     val sessionId: String
 )

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareResponse.kt
@@ -1,9 +1,12 @@
 package dev.keiji.deviceintegrity.api.keyattestation
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class PrepareResponse(
-    val nonceBase64UrlEncoded: String, // Base64URL Encoded
-    val challengeBase64UrlEncoded: String // Base64URL Encoded
+    @SerialName("nonce")
+    val nonceBase64UrlEncoded: String,
+    @SerialName("challenge")
+    val challengeBase64UrlEncoded: String
 )

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcRequest.kt
@@ -1,11 +1,16 @@
 package dev.keiji.deviceintegrity.api.keyattestation
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class VerifyEcRequest(
+    @SerialName("session_id")
     val sessionId: String,
-    val signedDataBase64UrlEncoded: String, // Base64URL Encoded
-    val nonceBBase64UrlEncoded: String, // Base64URL Encoded
-    val certificateChainBase64UrlEncoded: List<String> // List of Base64URL Encoded strings
+    @SerialName("signed_data")
+    val signedDataBase64UrlEncoded: String,
+    @SerialName("nonce_b")
+    val nonceBBase64UrlEncoded: String,
+    @SerialName("certificate_chain")
+    val certificateChainBase64UrlEncoded: List<String>
 )

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
@@ -1,23 +1,32 @@
 package dev.keiji.deviceintegrity.api.keyattestation
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class DecodedCertificateChainMock(
+    @SerialName("mocked_detail")
     val mockedDetail: String
 )
 
 @Serializable
 data class AttestationPropertiesMock(
-    val mockedSoftwareEnforced: Map<String, String>, // Assuming simple key-value, adjust if complex
-    val mockedTeeEnforced: Map<String, String>    // Assuming simple key-value, adjust if complex
+    @SerialName("mocked_software_enforced")
+    val mockedSoftwareEnforced: Map<String, String>,
+    @SerialName("mocked_tee_enforced")
+    val mockedTeeEnforced: Map<String, String>
 )
 
 @Serializable
 data class VerifyEcResponse(
+    @SerialName("session_id")
     val sessionId: String,
+    @SerialName("is_verified")
     val isVerified: Boolean,
+    @SerialName("reason")
     val reason: String? = null,
+    @SerialName("decoded_certificate_chain")
     val decodedCertificateChain: DecodedCertificateChainMock,
+    @SerialName("attestation_properties")
     val attestationProperties: AttestationPropertiesMock
 )

--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -48,13 +48,13 @@ def store_key_attestation_session(session_id, nonce_encoded, challenge_encoded):
     key = datastore_client.key(KEY_ATTESTATION_SESSION_KIND, session_id)
     entity = datastore.Entity(key=key)
     entity.update({
-        'sessionId': session_id,
+        'session_id': session_id,
         'nonce': nonce_encoded,
         'challenge': challenge_encoded,
         'generated_at': now,
     })
     datastore_client.put(entity)
-    logger.info(f"Stored key attestation session for sessionId: {session_id}")
+    logger.info(f"Stored key attestation session for session_id: {session_id}")
     # Consider calling cleanup_expired_sessions() here or via a scheduled job
     cleanup_expired_sessions()
 
@@ -86,7 +86,7 @@ def cleanup_expired_sessions():
 def prepare_attestation():
     """
     Prepares for key attestation by generating a nonce and challenge.
-    Request body: { "sessionId": "string" }
+    Request body: { "session_id": "string" }
     Response body: { "nonce": "string (Base64URLEncoded)", "challenge": "string (Base64URLEncoded)" }
     """
     if not datastore_client:
@@ -99,10 +99,10 @@ def prepare_attestation():
             logger.warning("Prepare request missing JSON payload.")
             return jsonify({"error": "Missing JSON payload"}), 400
 
-        session_id = data.get('sessionId')
+        session_id = data.get('session_id')
         if not session_id or not isinstance(session_id, str) or not session_id.strip():
-            logger.warning(f"Prepare request with invalid sessionId: {session_id}")
-            return jsonify({"error": "'sessionId' must be a non-empty string"}), 400
+            logger.warning(f"Prepare request with invalid session_id: {session_id}")
+            return jsonify({"error": "'session_id' must be a non-empty string"}), 400
 
         # Generate nonce and challenge
         nonce_bytes = generate_random_bytes()
@@ -136,8 +136,8 @@ def prepare_attestation():
 def verify_ec_attestation():
     """
     Verifies the EC key attestation (mock implementation).
-    Request body: { "sessionId": "string", "signedData": "string (Base64Encoded)", "nonceB": "string (Base64Encoded)", "certificateChain": ["string (Base64Encoded)"] }
-    Response body: { "sessionId": "string", "isVerified": false, "reason": "Mock implementation", "decodedCertificateChain": { "mockedDetail": "This is a mock response for decoded certificate chain." }, "attestationProperties": { "mockedSoftwareEnforced": {}, "mockedTeeEnforced": {} } }
+    Request body: { "session_id": "string", "signed_data": "string (Base64Encoded)", "nonce_b": "string (Base64Encoded)", "certificate_chain": ["string (Base64Encoded)"] }
+    Response body: { "session_id": "string", "is_verified": false, "reason": "Mock implementation", "decoded_certificate_chain": { "mocked_detail": "This is a mock response for decoded certificate chain." }, "attestation_properties": { "mocked_software_enforced": {}, "mocked_tee_enforced": {} } }
     """
     try:
         data = request.get_json()
@@ -146,14 +146,14 @@ def verify_ec_attestation():
             return jsonify({"error": "Missing JSON payload"}), 400
 
         # Validate required fields (presence only for this mock)
-        session_id = data.get('sessionId')
-        signed_data = data.get('signedData')
-        nonce_b = data.get('nonceB')
-        certificate_chain = data.get('certificateChain')
+        session_id = data.get('session_id')
+        signed_data = data.get('signed_data')
+        nonce_b = data.get('nonce_b')
+        certificate_chain = data.get('certificate_chain')
 
         if not all([session_id, signed_data, nonce_b, certificate_chain]):
             logger.warning(f"Verify EC request for session {session_id} missing one or more required fields.")
-            return jsonify({"error": "Missing one or more required fields: sessionId, signedData, nonceB, certificateChain"}), 400
+            return jsonify({"error": "Missing one or more required fields: session_id, signed_data, nonce_b, certificate_chain"}), 400
 
         if not isinstance(session_id, str) or \
            not isinstance(signed_data, str) or \
@@ -165,18 +165,18 @@ def verify_ec_attestation():
 
         # Mock response
         mock_response = {
-            "sessionId": session_id,
-            "isVerified": False,
+            "session_id": session_id,
+            "is_verified": False,
             "reason": "Mock implementation",
-            "decodedCertificateChain": {
-                "mockedDetail": "This is a mock response for decoded certificate chain."
+            "decoded_certificate_chain": {
+                "mocked_detail": "This is a mock response for decoded certificate chain."
             },
-            "attestationProperties": {
-                "mockedSoftwareEnforced": {},
-                "mockedTeeEnforced": {}
+            "attestation_properties": {
+                "mocked_software_enforced": {},
+                "mocked_tee_enforced": {}
             }
         }
-        logger.info(f"Successfully processed mock EC verification for sessionId: {session_id}")
+        logger.info(f"Successfully processed mock EC verification for session_id: {session_id}")
         return jsonify(mock_response), 200
 
     except Exception as e:

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -39,7 +39,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PrepareResponseBody'
         '400':
-          description: Bad Request (e.g., missing sessionId).
+          description: Bad Request (e.g., missing session_id).
           content:
             application/json:
               schema:
@@ -89,24 +89,24 @@ components:
     PrepareRequestBody:
       type: object
       required:
-        - sessionId
+        - session_id
       properties:
-        sessionId:
+        session_id:
           type: string
           description: Client session ID.
           example: "session-12345-abcde"
     PrepareResponseBody:
       type: object
       required:
-        - nonceBase64UrlEncoded
-        - challengeBase64UrlEncoded
+        - nonce
+        - challenge
       properties:
-        nonceBase64UrlEncoded:
+        nonce:
           type: string
           format: byte
           description: Base64URL-encoded nonce.
           example: "SGVsbG8gd29ybGQhMTIzNDU2Nzg5MA=="
-        challengeBase64UrlEncoded:
+        challenge:
           type: string
           format: byte
           description: Base64URL-encoded challenge.
@@ -114,44 +114,43 @@ components:
     VerifyEcRequestBody:
       type: object
       required:
-        - sessionId
-        - signedDataBase64Encoded
-        - nonceBBase64Encoded
-        - certificateChainBase64Encoded
+        - session_id
+        - signed_data
+        - nonce_b
+        - certificate_chain
       properties:
-        sessionId:
+        session_id:
           type: string
           description: Client session ID.
           example: "session-12345-abcde"
-        signedDataBase64Encoded:
+        signed_data:
           type: string
           format: byte
           description: Base64-encoded signed data.
           example: "U2lnbmVkRGF0YTEyMzQ1Njc4OTA="
-        nonceBBase64Encoded:
+        nonce_b:
           type: string
           format: byte
           description: Base64-encoded second nonce from client.
           example: "Tm9uY2VCMTIzNDU2Nzg5MA=="
-        certificateChainBase64Encoded:
+        certificate_chain:
           type: array
           items:
             type: string
             format: byte
-          description: Array of Base64-encoded certificate strings. # Description for the array itself
-          # item description is implicitly "Base64-encoded certificate strings" due to items.type and items.format
+          description: Array of Base64-encoded certificate strings.
           example: ["Y2VydDE=", "Y2VydDI="]
     VerifyEcResponseBody:
       type: object
       required:
-        - sessionId
-        - isVerified
+        - session_id
+        - is_verified
       properties:
-        sessionId:
+        session_id:
           type: string
           description: Client session ID.
           example: "session-12345-abcde"
-        isVerified:
+        is_verified:
           type: boolean
           description: Result of the verification.
           example: false
@@ -159,28 +158,26 @@ components:
           type: string
           description: Reason for verification failure (optional).
           example: "Mock implementation"
-        decodedCertificateChain:
+        decoded_certificate_chain:
           type: object
           description: Mocked decoded certificate chain details.
-          properties: # Added properties for clarity, even if just a mock
-            mockedDetail:
+          properties:
+            mocked_detail:
               type: string
               example: "This is a mock response for decoded certificate chain."
-          required: # Added required for clarity
-            - mockedDetail
-        attestationProperties:
+          required:
+            - mocked_detail
+        attestation_properties:
           type: object
           description: Mocked attestation properties.
-          properties: # Added properties for clarity
-            mockedSoftwareEnforced:
+          properties:
+            mocked_software_enforced:
               type: object
-              # Add further properties if known, else empty object is fine
-            mockedTeeEnforced:
+            mocked_tee_enforced:
               type: object
-              # Add further properties if known, else empty object is fine
-          required: # Added required for clarity
-            - mockedSoftwareEnforced
-            - mockedTeeEnforced
+          required:
+            - mocked_software_enforced
+            - mocked_tee_enforced
     ErrorResponse:
       type: object
       required:


### PR DESCRIPTION
…ixes

Close #277 

- Modified Android client data classes to use simple snake_case JSON keys via @SerialName, while retaining original field names with 'Base64Encoded' suffixes.
- Updated OpenAPI specification (openapi.yaml) to define JSON keys as simple snake_case without suffixes.
- Modified Python server implementation (key_attestation.py) to expect and produce simple snake_case JSON keys without suffixes.
- Removed temporary edit-marker comments from server code.