### PR TITLE
Refactor: Use Base64 URL safe with no padding for KeyAttestation

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/util/Base64Utils.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/util/Base64Utils.kt
@@ -1,0 +1,20 @@
+package dev.keiji.deviceintegrity.ui.main.util
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.PaddingOption
+
+/**
+ * Utility object for Base64 encoding and decoding.
+ */
+object Base64Utils {
+
+    /**
+     * Provides a Base64 instance that is URL and filename safe (RFC 4648 section 5)
+     * and configured to **not** use padding.
+     *
+     * Note: `kotlin.io.encoding.Base64.UrlSafe` by default uses `PaddingOption.PRESENT`.
+     * This instance explicitly uses `PaddingOption.ABSENT`.
+     */
+    val UrlSafeNoPadding: Base64
+        get() = Base64.UrlSafe.withPadding(PaddingOption.ABSENT)
+}


### PR DESCRIPTION
Introduced `Base64Utils` to provide a Base64 instance configured for URL safety and no padding (`PaddingOption.ABSENT`).

Refactored `KeyAttestationViewModel` to use this utility for all Base64 encoding and decoding of nonce, challenge, and other cryptographic data related to KeyAttestation.

This addresses the requirement to explicitly use no padding, as the default for `kotlin.io.encoding.Base64.UrlSafe` is `PaddingOption.PRESENT`.