### PR TITLE
Fix: Add cryptography and asn1crypto dependencies for key attestation

### DIFF
--- a/server/key_attestation/requirements.txt
+++ b/server/key_attestation/requirements.txt
@@ -3,3 +3,5 @@ gunicorn>=20.0.0,<24.0.0 # Gunicorn is a common WSGI server for GAE Python apps
 google-cloud-datastore>=2.5.0,<3.0.0 # For Google Cloud Datastore access
 google-api-python-client>=2.0.0,<3.0.0 # For calling Google APIs, including Play Integrity
 google-auth>=2.0.0,<3.0.0 # For authentication with Google Cloud services
+cryptography>=45.0.5,<46.0.0 # For X.509 certificate parsing and signature verification
+asn1crypto>=1.5.0,<2.0.0 # For parsing ASN.1 structures in attestation certificates


### PR DESCRIPTION
These libraries are required by `key_attestation.py` for X.509 certificate parsing, ASN.1 structure decoding, and cryptographic signature verification.

Adding them to `requirements.txt` resolves the `ModuleNotFoundError` encountered during server startup and ensures the key attestation service can function correctly within its Docker container.