### PR TITLE
Fix: Handle non-existent KeyDescription gracefully

### DIFF
--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -323,6 +323,10 @@ def parse_key_description(key_desc_bytes):
     """
     key_desc_sequence = asn1_core.Sequence.load(key_desc_bytes)
 
+    if key_desc_sequence is None:
+        logger.warning("Failed to load KeyDescription ASN.1 sequence. Input bytes may be malformed, empty, or not a sequence.")
+        return None
+
     parsed_data = {}
     # Order of fields in KeyDescription SEQUENCE (varies slightly by version, but first few are consistent)
     # attestationVersion INTEGER,


### PR DESCRIPTION
Modified `parse_key_description` to return `None` if the KeyDescription ASN.1 sequence cannot be loaded from the provided bytes. This prevents a TypeError and allows calling functions to handle the absence of attestation properties, typically resulting in a client error if essential data like the attestation challenge is missing.