### PR TITLE
Refactor: Use pyasn1 for Android key attestation parsing

### DIFF
--- a/server/key_attestation/requirements.txt
+++ b/server/key_attestation/requirements.txt
@@ -4,4 +4,4 @@ google-cloud-datastore>=2.5.0,<3.0.0 # For Google Cloud Datastore access
 google-api-python-client>=2.0.0,<3.0.0 # For calling Google APIs, including Play Integrity
 google-auth>=2.0.0,<3.0.0 # For authentication with Google Cloud services
 cryptography>=45.0.5,<46.0.0 # For X.509 certificate parsing and signature verification
-asn1crypto>=1.5.0,<2.0.0 # For parsing ASN.1 structures in attestation certificates
+pyasn1>=0.5.1,<0.6.0 # For parsing ASN.1 structures


### PR DESCRIPTION
Replaces asn1crypto with pyasn1 for parsing the ASN.1 extension data in Android key attestation certificates.

Updates include:
- Modified requirements.txt.
- Replaced ASN.1 constants with a more comprehensive list.
- Integrated new pyasn1-based parsing functions for KeyDescription, AuthorizationList, RootOfTrust, and AttestationApplicationID.
- Adjusted TAG_MGF_DIGEST parsing to correctly interpret a list of integers.