### PR TITLE
Refactor KeyAttestation response handling



### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
@@ -4,29 +4,80 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
 @Serializable
-data class DecodedCertificateChainMock(
-    @SerialName("mocked_detail")
-    val mockedDetail: String
+data class AttestationApplicationId(
+    @SerialName("application_signature")
+    val applicationSignature: String?, // Made nullable
+    @SerialName("attestation_application_id")
+    val attestationApplicationId: String?, // Made nullable
+    @SerialName("attestation_application_version_code")
+    val attestationApplicationVersionCode: Int? // Made nullable
 )
 
 @Serializable
-data class AttestationPropertiesMock(
-    @SerialName("mocked_software_enforced")
-    val mockedSoftwareEnforced: Map<String, String>,
-    @SerialName("mocked_tee_enforced")
-    val mockedTeeEnforced: Map<String, String>
+data class RootOfTrust(
+    @SerialName("device_locked")
+    val deviceLocked: Boolean?, // Made nullable
+    @SerialName("verified_boot_hash")
+    val verifiedBootHash: String?, // Made nullable
+    @SerialName("verified_boot_key")
+    val verifiedBootKey: String?, // Made nullable
+    @SerialName("verified_boot_state")
+    val verifiedBootState: Int? // Made nullable
+)
+
+@Serializable
+data class AuthorizationList(
+    // Fields from SoftwareEnforced
+    @SerialName("attestation_application_id")
+    val attestationApplicationId: AttestationApplicationId?,
+    @SerialName("creation_datetime")
+    val creationDatetime: Long?,
+
+    // Fields from TeeEnforced
+    @SerialName("algorithm")
+    val algorithm: Int?,
+    @SerialName("boot_patch_level")
+    val bootPatchLevel: Int?,
+    @SerialName("digests")
+    val digests: List<Int>?,
+    @SerialName("ec_curve")
+    val ecCurve: Int?,
+    @SerialName("key_size")
+    val keySize: Int?,
+    @SerialName("no_auth_required")
+    val noAuthRequired: Boolean?,
+    @SerialName("origin")
+    val origin: String?,
+    @SerialName("os_patch_level")
+    val osPatchLevel: Int?,
+    @SerialName("os_version")
+    val osVersion: Int?,
+    @SerialName("purpose")
+    val purpose: List<Int>?,
+    @SerialName("root_of_trust")
+    val rootOfTrust: RootOfTrust?,
+    @SerialName("vendor_patch_level")
+    val vendorPatchLevel: Int?
 )
 
 @Serializable
 data class VerifyEcResponse(
-    @SerialName("session_id")
-    val sessionId: String,
+    @SerialName("attestation_security_level")
+    val attestationSecurityLevel: Int,
+    @SerialName("attestation_version")
+    val attestationVersion: Int,
     @SerialName("is_verified")
     val isVerified: Boolean,
+    @SerialName("keymint_security_level")
+    val keymintSecurityLevel: Int,
+    @SerialName("keymint_version")
+    val keymintVersion: Int,
     @SerialName("reason")
     val reason: String? = null,
-    @SerialName("decoded_certificate_chain")
-    val decodedCertificateChain: DecodedCertificateChainMock,
-    @SerialName("attestation_properties")
-    val attestationProperties: AttestationPropertiesMock
+    @SerialName("session_id")
+    val sessionId: String,
+    @SerialName("software_enforced_properties")
+    val softwareEnforcedProperties: AuthorizationList?, // Changed to AuthorizationList?
+    @SerialName("tee_enforced_properties")
+    val teeEnforcedProperties: AuthorizationList? // Changed to AuthorizationList?
 )

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
@@ -1,63 +1,60 @@
 package dev.keiji.deviceintegrity.api.keyattestation
 
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 @Serializable
 data class AttestationApplicationId(
     @SerialName("application_signature")
-    val applicationSignature: String?, // Made nullable
+    val applicationSignature: String,
     @SerialName("attestation_application_id")
-    val attestationApplicationId: String?, // Made nullable
+    val attestationApplicationId: String,
     @SerialName("attestation_application_version_code")
-    val attestationApplicationVersionCode: Int? // Made nullable
+    val attestationApplicationVersionCode: Int
 )
 
 @Serializable
 data class RootOfTrust(
     @SerialName("device_locked")
-    val deviceLocked: Boolean?, // Made nullable
+    val deviceLocked: Boolean,
     @SerialName("verified_boot_hash")
-    val verifiedBootHash: String?, // Made nullable
+    val verifiedBootHash: String,
     @SerialName("verified_boot_key")
-    val verifiedBootKey: String?, // Made nullable
+    val verifiedBootKey: String,
     @SerialName("verified_boot_state")
-    val verifiedBootState: Int? // Made nullable
+    val verifiedBootState: Int
 )
 
 @Serializable
 data class AuthorizationList(
-    // Fields from SoftwareEnforced
     @SerialName("attestation_application_id")
-    val attestationApplicationId: AttestationApplicationId?,
+    val attestationApplicationId: AttestationApplicationId? = null,
     @SerialName("creation_datetime")
-    val creationDatetime: Long?,
-
-    // Fields from TeeEnforced
+    val creationDatetime: Long? = null,
     @SerialName("algorithm")
-    val algorithm: Int?,
+    val algorithm: Int? = null,
     @SerialName("boot_patch_level")
-    val bootPatchLevel: Int?,
+    val bootPatchLevel: Int? = null,
     @SerialName("digests")
-    val digests: List<Int>?,
+    val digests: List<Int>? = null,
     @SerialName("ec_curve")
-    val ecCurve: Int?,
+    val ecCurve: Int? = null,
     @SerialName("key_size")
-    val keySize: Int?,
+    val keySize: Int? = null,
     @SerialName("no_auth_required")
-    val noAuthRequired: Boolean?,
+    val noAuthRequired: Boolean? = null,
     @SerialName("origin")
-    val origin: String?,
+    val origin: String? = null,
     @SerialName("os_patch_level")
-    val osPatchLevel: Int?,
+    val osPatchLevel: Int? = null,
     @SerialName("os_version")
-    val osVersion: Int?,
+    val osVersion: Int? = null,
     @SerialName("purpose")
-    val purpose: List<Int>?,
+    val purpose: List<Int>? = null,
     @SerialName("root_of_trust")
-    val rootOfTrust: RootOfTrust?,
+    val rootOfTrust: RootOfTrust? = null,
     @SerialName("vendor_patch_level")
-    val vendorPatchLevel: Int?
+    val vendorPatchLevel: Int? = null
 )
 
 @Serializable
@@ -77,7 +74,7 @@ data class VerifyEcResponse(
     @SerialName("session_id")
     val sessionId: String,
     @SerialName("software_enforced_properties")
-    val softwareEnforcedProperties: AuthorizationList?, // Changed to AuthorizationList?
+    val softwareEnforcedProperties: AuthorizationList,
     @SerialName("tee_enforced_properties")
-    val teeEnforcedProperties: AuthorizationList? // Changed to AuthorizationList?
+    val teeEnforcedProperties: AuthorizationList?
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -186,8 +186,51 @@ class KeyAttestationViewModel @Inject constructor(
                 }
 
                 if (response.isVerified) {
+                    val statusBuilder = StringBuilder()
+                    statusBuilder.appendLine("Verification successful.")
+                    statusBuilder.appendLine("Session ID: ${response.sessionId}")
+                    statusBuilder.appendLine("Is Verified: ${response.isVerified}")
+                    statusBuilder.appendLine("Attestation Security Level: ${response.attestationSecurityLevel}")
+                    statusBuilder.appendLine("Attestation Version: ${response.attestationVersion}")
+                    statusBuilder.appendLine("KeyMint Security Level: ${response.keymintSecurityLevel}")
+                    statusBuilder.appendLine("KeyMint Version: ${response.keymintVersion}")
+                    statusBuilder.appendLine("Reason: ${response.reason ?: "N/A"}")
+
+                    statusBuilder.appendLine("\nSoftware Enforced Properties:")
+                    response.softwareEnforcedProperties.let { props ->
+                        statusBuilder.appendLine("  Attestation Application ID:")
+                        props.attestationApplicationId.let { appId ->
+                            statusBuilder.appendLine("    Application Signature: ${appId.applicationSignature}")
+                            statusBuilder.appendLine("    Attestation Application ID: ${appId.attestationApplicationId}")
+                            statusBuilder.appendLine("    Attestation Application Version Code: ${appId.attestationApplicationVersionCode}")
+                        }
+                        statusBuilder.appendLine("  Creation Datetime: ${props.creationDatetime}")
+                    }
+
+                    statusBuilder.appendLine("\nTEE Enforced Properties:")
+                    response.teeEnforcedProperties.let { props ->
+                        statusBuilder.appendLine("  Algorithm: ${props.algorithm}")
+                        statusBuilder.appendLine("  Boot Patch Level: ${props.bootPatchLevel}")
+                        statusBuilder.appendLine("  Digests: ${props.digests.joinToString()}")
+                        statusBuilder.appendLine("  EC Curve: ${props.ecCurve}")
+                        statusBuilder.appendLine("  Key Size: ${props.keySize}")
+                        statusBuilder.appendLine("  No Auth Required: ${props.noAuthRequired}")
+                        statusBuilder.appendLine("  Origin: ${props.origin}")
+                        statusBuilder.appendLine("  OS Patch Level: ${props.osPatchLevel}")
+                        statusBuilder.appendLine("  OS Version: ${props.osVersion}")
+                        statusBuilder.appendLine("  Purpose: ${props.purpose.joinToString()}")
+                        props.rootOfTrust.let { rot ->
+                            statusBuilder.appendLine("  Root of Trust:")
+                            statusBuilder.appendLine("    Device Locked: ${rot.deviceLocked}")
+                            statusBuilder.appendLine("    Verified Boot Hash: ${rot.verifiedBootHash}")
+                            statusBuilder.appendLine("    Verified Boot Key: ${rot.verifiedBootKey}")
+                            statusBuilder.appendLine("    Verified Boot State: ${rot.verifiedBootState}")
+                        }
+                        statusBuilder.appendLine("  Vendor Patch Level: ${props.vendorPatchLevel}")
+                    }
+
                     _uiState.update {
-                        it.copy(status = "Verification successful. Session: ${response.sessionId}, Verified: ${response.isVerified}")
+                        it.copy(status = statusBuilder.toString())
                     }
                 } else {
                     _uiState.update {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -197,37 +197,62 @@ class KeyAttestationViewModel @Inject constructor(
                     statusBuilder.appendLine("Reason: ${response.reason ?: "N/A"}")
 
                     statusBuilder.appendLine("\nSoftware Enforced Properties:")
-                    response.softwareEnforcedProperties.let { props ->
+                    response.softwareEnforcedProperties?.let { props ->
                         statusBuilder.appendLine("  Attestation Application ID:")
-                        props.attestationApplicationId.let { appId ->
-                            statusBuilder.appendLine("    Application Signature: ${appId.applicationSignature}")
-                            statusBuilder.appendLine("    Attestation Application ID: ${appId.attestationApplicationId}")
-                            statusBuilder.appendLine("    Attestation Application Version Code: ${appId.attestationApplicationVersionCode}")
-                        }
-                        statusBuilder.appendLine("  Creation Datetime: ${props.creationDatetime}")
-                    }
+                        props.attestationApplicationId?.let { appId ->
+                            statusBuilder.appendLine("    Application Signature: ${appId.applicationSignature ?: "N/A"}")
+                            statusBuilder.appendLine("    Attestation Application ID: ${appId.attestationApplicationId ?: "N/A"}")
+                            statusBuilder.appendLine("    Attestation Application Version Code: ${appId.attestationApplicationVersionCode ?: "N/A"}")
+                        } ?: statusBuilder.appendLine("    N/A")
+                        statusBuilder.appendLine("  Creation Datetime: ${props.creationDatetime ?: "N/A"}")
+                        statusBuilder.appendLine("  Algorithm: ${props.algorithm ?: "N/A"}")
+                        statusBuilder.appendLine("  Boot Patch Level: ${props.bootPatchLevel ?: "N/A"}")
+                        statusBuilder.appendLine("  Digests: ${props.digests?.joinToString() ?: "N/A"}")
+                        statusBuilder.appendLine("  EC Curve: ${props.ecCurve ?: "N/A"}")
+                        statusBuilder.appendLine("  Key Size: ${props.keySize ?: "N/A"}")
+                        statusBuilder.appendLine("  No Auth Required: ${props.noAuthRequired ?: "N/A"}")
+                        statusBuilder.appendLine("  Origin: ${props.origin ?: "N/A"}")
+                        statusBuilder.appendLine("  OS Patch Level: ${props.osPatchLevel ?: "N/A"}")
+                        statusBuilder.appendLine("  OS Version: ${props.osVersion ?: "N/A"}")
+                        statusBuilder.appendLine("  Purpose: ${props.purpose?.joinToString() ?: "N/A"}")
+                        props.rootOfTrust?.let { rot ->
+                            statusBuilder.appendLine("  Root of Trust:")
+                            statusBuilder.appendLine("    Device Locked: ${rot.deviceLocked ?: "N/A"}")
+                            statusBuilder.appendLine("    Verified Boot Hash: ${rot.verifiedBootHash ?: "N/A"}")
+                            statusBuilder.appendLine("    Verified Boot Key: ${rot.verifiedBootKey ?: "N/A"}")
+                            statusBuilder.appendLine("    Verified Boot State: ${rot.verifiedBootState ?: "N/A"}")
+                        } ?: statusBuilder.appendLine("  Root of Trust: N/A")
+                        statusBuilder.appendLine("  Vendor Patch Level: ${props.vendorPatchLevel ?: "N/A"}")
+                    } ?: statusBuilder.appendLine("  N/A")
 
                     statusBuilder.appendLine("\nTEE Enforced Properties:")
-                    response.teeEnforcedProperties.let { props ->
-                        statusBuilder.appendLine("  Algorithm: ${props.algorithm}")
-                        statusBuilder.appendLine("  Boot Patch Level: ${props.bootPatchLevel}")
-                        statusBuilder.appendLine("  Digests: ${props.digests.joinToString()}")
-                        statusBuilder.appendLine("  EC Curve: ${props.ecCurve}")
-                        statusBuilder.appendLine("  Key Size: ${props.keySize}")
-                        statusBuilder.appendLine("  No Auth Required: ${props.noAuthRequired}")
-                        statusBuilder.appendLine("  Origin: ${props.origin}")
-                        statusBuilder.appendLine("  OS Patch Level: ${props.osPatchLevel}")
-                        statusBuilder.appendLine("  OS Version: ${props.osVersion}")
-                        statusBuilder.appendLine("  Purpose: ${props.purpose.joinToString()}")
-                        props.rootOfTrust.let { rot ->
+                    response.teeEnforcedProperties?.let { props ->
+                        statusBuilder.appendLine("  Attestation Application ID:")
+                        props.attestationApplicationId?.let { appId ->
+                            statusBuilder.appendLine("    Application Signature: ${appId.applicationSignature ?: "N/A"}")
+                            statusBuilder.appendLine("    Attestation Application ID: ${appId.attestationApplicationId ?: "N/A"}")
+                            statusBuilder.appendLine("    Attestation Application Version Code: ${appId.attestationApplicationVersionCode ?: "N/A"}")
+                        } ?: statusBuilder.appendLine("    N/A")
+                        statusBuilder.appendLine("  Creation Datetime: ${props.creationDatetime ?: "N/A"}")
+                        statusBuilder.appendLine("  Algorithm: ${props.algorithm ?: "N/A"}")
+                        statusBuilder.appendLine("  Boot Patch Level: ${props.bootPatchLevel ?: "N/A"}")
+                        statusBuilder.appendLine("  Digests: ${props.digests?.joinToString() ?: "N/A"}")
+                        statusBuilder.appendLine("  EC Curve: ${props.ecCurve ?: "N/A"}")
+                        statusBuilder.appendLine("  Key Size: ${props.keySize ?: "N/A"}")
+                        statusBuilder.appendLine("  No Auth Required: ${props.noAuthRequired ?: "N/A"}")
+                        statusBuilder.appendLine("  Origin: ${props.origin ?: "N/A"}")
+                        statusBuilder.appendLine("  OS Patch Level: ${props.osPatchLevel ?: "N/A"}")
+                        statusBuilder.appendLine("  OS Version: ${props.osVersion ?: "N/A"}")
+                        statusBuilder.appendLine("  Purpose: ${props.purpose?.joinToString() ?: "N/A"}")
+                        props.rootOfTrust?.let { rot ->
                             statusBuilder.appendLine("  Root of Trust:")
-                            statusBuilder.appendLine("    Device Locked: ${rot.deviceLocked}")
-                            statusBuilder.appendLine("    Verified Boot Hash: ${rot.verifiedBootHash}")
-                            statusBuilder.appendLine("    Verified Boot Key: ${rot.verifiedBootKey}")
-                            statusBuilder.appendLine("    Verified Boot State: ${rot.verifiedBootState}")
-                        }
-                        statusBuilder.appendLine("  Vendor Patch Level: ${props.vendorPatchLevel}")
-                    }
+                            statusBuilder.appendLine("    Device Locked: ${rot.deviceLocked ?: "N/A"}")
+                            statusBuilder.appendLine("    Verified Boot Hash: ${rot.verifiedBootHash ?: "N/A"}")
+                            statusBuilder.appendLine("    Verified Boot Key: ${rot.verifiedBootKey ?: "N/A"}")
+                            statusBuilder.appendLine("    Verified Boot State: ${rot.verifiedBootState ?: "N/A"}")
+                        } ?: statusBuilder.appendLine("  Root of Trust: N/A")
+                        statusBuilder.appendLine("  Vendor Patch Level: ${props.vendorPatchLevel ?: "N/A"}")
+                    } ?: statusBuilder.appendLine("  N/A")
 
                     _uiState.update {
                         it.copy(status = statusBuilder.toString())


### PR DESCRIPTION
Merged SoftwareEnforced and TeeEnforced into a single AuthorizationList class with nullable properties to represent the attestation data.

Updated VerifyEcResponse to use the new AuthorizationList.
Updated KeyAttestationViewModel to correctly parse the new response structure and display all fields, handling nullability by showing 'N/A' for missing values.
All relevant unit tests pass and the application builds successfully.