### PR TITLE
feat: Display device and security info in Key Attestation

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
@@ -76,5 +76,9 @@ data class VerifyEcResponse(
     @SerialName("software_enforced_properties")
     val softwareEnforcedProperties: AuthorizationList,
     @SerialName("tee_enforced_properties")
-    val teeEnforcedProperties: AuthorizationList?
+    val teeEnforcedProperties: AuthorizationList?,
+    @SerialName("device_info")
+    val deviceInfo: AuthorizationList?,
+    @SerialName("security_info")
+    val securityInfo: AuthorizationList?
 )

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
@@ -1,5 +1,7 @@
 package dev.keiji.deviceintegrity.api.keyattestation
 
+import dev.keiji.deviceintegrity.api.DeviceInfo
+import dev.keiji.deviceintegrity.api.SecurityInfo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -78,7 +80,7 @@ data class VerifyEcResponse(
     @SerialName("tee_enforced_properties")
     val teeEnforcedProperties: AuthorizationList?,
     @SerialName("device_info")
-    val deviceInfo: AuthorizationList?,
+    val deviceInfo: DeviceInfo,
     @SerialName("security_info")
-    val securityInfo: AuthorizationList?
+    val securityInfo: SecurityInfo
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -195,6 +195,40 @@ fun KeyAttestationScreen(
                     }
                 }
             }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Display Device Info
+            if (uiState.deviceInfoText.isNotEmpty()) {
+                Text(text = "Device Info:", style = MaterialTheme.typography.titleMedium)
+                Spacer(modifier = Modifier.height(4.dp))
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                ) {
+                    Text(
+                        text = uiState.deviceInfoText,
+                        modifier = Modifier.padding(12.dp),
+                        style = MaterialTheme.typography.bodySmall // Use a smaller font for potentially long text
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            // Display Security Info
+            if (uiState.securityInfoText.isNotEmpty()) {
+                Text(text = "Security Info:", style = MaterialTheme.typography.titleMedium)
+                Spacer(modifier = Modifier.height(4.dp))
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                ) {
+                    Text(
+                        text = uiState.securityInfoText,
+                        modifier = Modifier.padding(12.dp),
+                        style = MaterialTheme.typography.bodySmall // Use a smaller font for potentially long text
+                    )
+                }
+            }
         }
     }
 }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -16,5 +16,7 @@ data class KeyAttestationUiState(
     val status: String = "", // Keep for general status messages (e.g., "Fetching...", "Failed...")
     val verificationResultItems: List<AttestationInfoItem> = emptyList(), // New field for structured results
     val sessionId: String? = null,
-    val generatedKeyPairData: KeyPairData? = null
+    val generatedKeyPairData: KeyPairData? = null,
+    val deviceInfoText: String = "",
+    val securityInfoText: String = ""
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -189,8 +189,8 @@ class KeyAttestationViewModel @Inject constructor(
 
                 if (response.isVerified) {
                     val resultItems = buildVerificationResultList(response)
-                    val deviceInfoText = convertAuthorizationListToString(response.deviceInfo)
-                    val securityInfoText = convertAuthorizationListToString(response.securityInfo)
+                    val deviceInfoText = convertDeviceInfoToString(response.deviceInfo)
+                    val securityInfoText = convertSecurityInfoToString(response.securityInfo)
                     _uiState.update {
                         it.copy(
                             status = "Verification successful.", // General status
@@ -211,11 +211,30 @@ class KeyAttestationViewModel @Inject constructor(
         }
     }
 
-    private fun convertAuthorizationListToString(authorizationList: AuthorizationList?): String {
-        authorizationList ?: return "N/A"
-        // A simple way to convert to string. For a more structured output, consider using a JSON library
-        // or manually iterating and formatting each field.
-        return authorizationList.toString()
+    private fun convertDeviceInfoToString(deviceInfo: DeviceInfo): String {
+        return """
+            Brand: ${deviceInfo.brand}
+            Model: ${deviceInfo.model}
+            Device: ${deviceInfo.device}
+            Product: ${deviceInfo.product}
+            Manufacturer: ${deviceInfo.manufacturer}
+            Hardware: ${deviceInfo.hardware}
+            Board: ${deviceInfo.board}
+            Bootloader: ${deviceInfo.bootloader}
+            Version Release: ${deviceInfo.versionRelease}
+            SDK Int: ${deviceInfo.sdkInt}
+            Fingerprint: ${deviceInfo.fingerprint}
+            Security Patch: ${deviceInfo.securityPatch}
+        """.trimIndent()
+    }
+
+    private fun convertSecurityInfoToString(securityInfo: SecurityInfo): String {
+        return """
+            Is Device Lock Enabled: ${securityInfo.isDeviceLockEnabled}
+            Is Biometrics Enabled: ${securityInfo.isBiometricsEnabled}
+            Has Class3 Authenticator: ${securityInfo.hasClass3Authenticator}
+            Has Strongbox: ${securityInfo.hasStrongbox}
+        """.trimIndent()
     }
 
     private fun buildVerificationResultList(response: VerifyEcResponse): List<AttestationInfoItem> {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -189,10 +189,14 @@ class KeyAttestationViewModel @Inject constructor(
 
                 if (response.isVerified) {
                     val resultItems = buildVerificationResultList(response)
+                    val deviceInfoText = convertAuthorizationListToString(response.deviceInfo)
+                    val securityInfoText = convertAuthorizationListToString(response.securityInfo)
                     _uiState.update {
                         it.copy(
                             status = "Verification successful.", // General status
-                            verificationResultItems = resultItems
+                            verificationResultItems = resultItems,
+                            deviceInfoText = deviceInfoText,
+                            securityInfoText = securityInfoText
                         )
                     }
                 } else {
@@ -205,6 +209,13 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update { it.copy(status = "Failed to verify KeyAttestation: ${e.message}") }
             }
         }
+    }
+
+    private fun convertAuthorizationListToString(authorizationList: AuthorizationList?): String {
+        authorizationList ?: return "N/A"
+        // A simple way to convert to string. For a more structured output, consider using a JSON library
+        // or manually iterating and formatting each field.
+        return authorizationList.toString()
     }
 
     private fun buildVerificationResultList(response: VerifyEcResponse): List<AttestationInfoItem> {

--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -723,7 +723,9 @@ def verify_ec_attestation():
             "keymint_version": attestation_properties.get('keymint_or_keymaster_version'),
             "keymint_security_level": attestation_properties.get('keymint_or_keymaster_security_level'),
             "software_enforced_properties": attestation_properties.get('software_enforced', {}),
-            "tee_enforced_properties": attestation_properties.get('hardware_enforced', {}) # Renamed from hardware_enforced for clarity
+            "tee_enforced_properties": attestation_properties.get('hardware_enforced', {}), # Renamed from hardware_enforced for clarity
+            "device_info": attestation_properties.get('hardware_enforced', {}),
+            "security_info": attestation_properties.get('software_enforced', {})
         }
         logger.info(f"Successfully verified EC key attestation for session_id: {session_id}")
         return jsonify(final_response), 200

--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -724,8 +724,8 @@ def verify_ec_attestation():
             "keymint_security_level": attestation_properties.get('keymint_or_keymaster_security_level'),
             "software_enforced_properties": attestation_properties.get('software_enforced', {}),
             "tee_enforced_properties": attestation_properties.get('hardware_enforced', {}), # Renamed from hardware_enforced for clarity
-            "device_info": attestation_properties.get('hardware_enforced', {}),
-            "security_info": attestation_properties.get('software_enforced', {})
+            "device_info": data.get('device_info', {}), # Get from request
+            "security_info": data.get('security_info', {}) # Get from request
         }
         logger.info(f"Successfully verified EC key attestation for session_id: {session_id}")
         return jsonify(final_response), 200


### PR DESCRIPTION
Server-side:
- Added device_info and security_info to the Key Attestation verification response.

Android client-side:
- Updated VerifyEcResponse DTO to include new fields.
- Modified KeyAttestationViewModel to process and store device/security info.
- Updated KeyAttestationScreen to display the new information.