### PR TITLE
Refactor: Unify Key Attestation result display

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -197,38 +197,8 @@ fun KeyAttestationScreen(
             }
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Display Device Info
-            if (uiState.deviceInfoText.isNotEmpty()) {
-                Text(text = "Device Info:", style = MaterialTheme.typography.titleMedium)
-                Spacer(modifier = Modifier.height(4.dp))
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-                ) {
-                    Text(
-                        text = uiState.deviceInfoText,
-                        modifier = Modifier.padding(12.dp),
-                        style = MaterialTheme.typography.bodySmall // Use a smaller font for potentially long text
-                    )
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-
-            // Display Security Info
-            if (uiState.securityInfoText.isNotEmpty()) {
-                Text(text = "Security Info:", style = MaterialTheme.typography.titleMedium)
-                Spacer(modifier = Modifier.height(4.dp))
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-                ) {
-                    Text(
-                        text = uiState.securityInfoText,
-                        modifier = Modifier.padding(12.dp),
-                        style = MaterialTheme.typography.bodySmall // Use a smaller font for potentially long text
-                    )
-                }
-            }
+            // Device Info and Security Info are now part of verificationResultItems
+            // So, the dedicated display sections below are no longer needed.
         }
     }
 }
@@ -252,6 +222,17 @@ private fun KeyAttestationScreenPreview() {
         AttestationInfoItem("Algorithm", "1", indentLevel = 1),
         AttestationInfoItem("TEE Enforced Properties", "", isHeader = true),
         AttestationInfoItem("Origin", "0", indentLevel = 1),
+
+        // Sample Device Info
+        AttestationInfoItem("Device Info", "", isHeader = true, indentLevel = 0),
+        AttestationInfoItem("Brand", "Google", indentLevel = 1),
+        AttestationInfoItem("Model", "Pixel Preview", indentLevel = 1),
+        AttestationInfoItem("SDK Int", "33", indentLevel = 1),
+
+        // Sample Security Info
+        AttestationInfoItem("Security Info", "", isHeader = true, indentLevel = 0),
+        AttestationInfoItem("Is Device Lock Enabled", "true", indentLevel = 1),
+        AttestationInfoItem("Has Strongbox", "true", indentLevel = 1),
     )
     KeyAttestationScreen(
         uiState = KeyAttestationUiState(

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -16,7 +16,6 @@ data class KeyAttestationUiState(
     val status: String = "", // Keep for general status messages (e.g., "Fetching...", "Failed...")
     val verificationResultItems: List<AttestationInfoItem> = emptyList(), // New field for structured results
     val sessionId: String? = null,
-    val generatedKeyPairData: KeyPairData? = null,
-    val deviceInfoText: String = "",
-    val securityInfoText: String = ""
+    val generatedKeyPairData: KeyPairData? = null
+    // deviceInfoText and securityInfoText are removed as their content will be part of verificationResultItems
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -189,14 +189,14 @@ class KeyAttestationViewModel @Inject constructor(
 
                 if (response.isVerified) {
                     val resultItems = buildVerificationResultList(response)
-                    val deviceInfoText = convertDeviceInfoToString(response.deviceInfo)
-                    val securityInfoText = convertSecurityInfoToString(response.securityInfo)
+                    // Append Device Info and Security Info to the main list
+                    resultItems.addAll(convertDeviceInfoToAttestationItems(response.deviceInfo))
+                    resultItems.addAll(convertSecurityInfoToAttestationItems(response.securityInfo))
+
                     _uiState.update {
                         it.copy(
                             status = "Verification successful.", // General status
-                            verificationResultItems = resultItems,
-                            deviceInfoText = deviceInfoText,
-                            securityInfoText = securityInfoText
+                            verificationResultItems = resultItems
                         )
                     }
                 } else {
@@ -211,33 +211,35 @@ class KeyAttestationViewModel @Inject constructor(
         }
     }
 
-    private fun convertDeviceInfoToString(deviceInfo: DeviceInfo): String {
-        return """
-            Brand: ${deviceInfo.brand}
-            Model: ${deviceInfo.model}
-            Device: ${deviceInfo.device}
-            Product: ${deviceInfo.product}
-            Manufacturer: ${deviceInfo.manufacturer}
-            Hardware: ${deviceInfo.hardware}
-            Board: ${deviceInfo.board}
-            Bootloader: ${deviceInfo.bootloader}
-            Version Release: ${deviceInfo.versionRelease}
-            SDK Int: ${deviceInfo.sdkInt}
-            Fingerprint: ${deviceInfo.fingerprint}
-            Security Patch: ${deviceInfo.securityPatch}
-        """.trimIndent()
+    private fun convertDeviceInfoToAttestationItems(deviceInfo: DeviceInfo): List<AttestationInfoItem> {
+        val items = mutableListOf<AttestationInfoItem>()
+        items.add(AttestationInfoItem("Device Info", "", isHeader = true, indentLevel = 0))
+        items.add(AttestationInfoItem("Brand", deviceInfo.brand, indentLevel = 1))
+        items.add(AttestationInfoItem("Model", deviceInfo.model, indentLevel = 1))
+        items.add(AttestationInfoItem("Device", deviceInfo.device, indentLevel = 1))
+        items.add(AttestationInfoItem("Product", deviceInfo.product, indentLevel = 1))
+        items.add(AttestationInfoItem("Manufacturer", deviceInfo.manufacturer, indentLevel = 1))
+        items.add(AttestationInfoItem("Hardware", deviceInfo.hardware, indentLevel = 1))
+        items.add(AttestationInfoItem("Board", deviceInfo.board, indentLevel = 1))
+        items.add(AttestationInfoItem("Bootloader", deviceInfo.bootloader, indentLevel = 1))
+        items.add(AttestationInfoItem("Version Release", deviceInfo.versionRelease, indentLevel = 1))
+        items.add(AttestationInfoItem("SDK Int", deviceInfo.sdkInt.toString(), indentLevel = 1))
+        items.add(AttestationInfoItem("Fingerprint", deviceInfo.fingerprint, indentLevel = 1))
+        items.add(AttestationInfoItem("Security Patch", deviceInfo.securityPatch, indentLevel = 1))
+        return items
     }
 
-    private fun convertSecurityInfoToString(securityInfo: SecurityInfo): String {
-        return """
-            Is Device Lock Enabled: ${securityInfo.isDeviceLockEnabled}
-            Is Biometrics Enabled: ${securityInfo.isBiometricsEnabled}
-            Has Class3 Authenticator: ${securityInfo.hasClass3Authenticator}
-            Has Strongbox: ${securityInfo.hasStrongbox}
-        """.trimIndent()
+    private fun convertSecurityInfoToAttestationItems(securityInfo: SecurityInfo): List<AttestationInfoItem> {
+        val items = mutableListOf<AttestationInfoItem>()
+        items.add(AttestationInfoItem("Security Info", "", isHeader = true, indentLevel = 0))
+        items.add(AttestationInfoItem("Is Device Lock Enabled", securityInfo.isDeviceLockEnabled.toString(), indentLevel = 1))
+        items.add(AttestationInfoItem("Is Biometrics Enabled", securityInfo.isBiometricsEnabled.toString(), indentLevel = 1))
+        items.add(AttestationInfoItem("Has Class3 Authenticator", securityInfo.hasClass3Authenticator.toString(), indentLevel = 1))
+        items.add(AttestationInfoItem("Has Strongbox", securityInfo.hasStrongbox.toString(), indentLevel = 1))
+        return items
     }
 
-    private fun buildVerificationResultList(response: VerifyEcResponse): List<AttestationInfoItem> {
+    private fun buildVerificationResultList(response: VerifyEcResponse): MutableList<AttestationInfoItem> {
         val items = mutableListOf<AttestationInfoItem>()
 
         items.add(AttestationInfoItem("Session ID", response.sessionId))


### PR DESCRIPTION
Refactor: Unify Key Attestation result display

Integrates Device Info and Security Info into the main
Key Attestation results list for a consistent UI presentation.

- Modified KeyAttestationViewModel to append Device and Security info
  as AttestationInfoItems to the main verificationResultItems list.
- Removed dedicated UI sections for Device and Security info in
  KeyAttestationScreen, as they are now rendered via the unified list.
- Updated KeyAttestationScreenPreview to reflect the new data structure.