### PR TITLE
Feat: Add copy and share functionality to KeyAttestation screen

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
@@ -196,16 +196,12 @@ fun DeviceIntegrityApp(
 
                     KeyAttestationScreen(
                         uiState = keyAttestationUiState,
-                        onSelectedKeyTypeChange = {
-                            keyAttestationViewModel.onSelectedKeyTypeChange(
-                                it
-                            )
-                        },
+                        onSelectedKeyTypeChange = { keyAttestationViewModel.onSelectedKeyTypeChange(it) },
                         onFetchNonceChallenge = { keyAttestationViewModel.fetchNonceChallenge() },
                         onGenerateKeyPair = { keyAttestationViewModel.generateKeyPair() },
                         onRequestVerifyKeyAttestation = { keyAttestationViewModel.requestVerifyKeyAttestation() },
-                        onCopyResults = { keyAttestationViewModel.onCopyResultsClicked() },
-                        onShareResults = { keyAttestationViewModel.onShareResultsClicked() }
+                        onClickCopy = { keyAttestationViewModel.onCopyResultsClicked() },
+                        onClickShare = { keyAttestationViewModel.onShareResultsClicked() }
                     )
                 }
                 composable(AppScreen.Menu.route) {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
@@ -1,14 +1,17 @@
-// Forcing a rebuild to attempt to clear persistent cache issues.
 package dev.keiji.deviceintegrity.ui.main
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import android.os.Build
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -165,13 +168,34 @@ fun DeviceIntegrityApp(
                 }
                 composable(AppScreen.KeyAttestation.route) {
                     val keyAttestationViewModel: KeyAttestationViewModel = hiltViewModel()
-                    val uiState by keyAttestationViewModel.uiState.collectAsStateWithLifecycle()
-                    // val context = LocalContext.current // Keep if needed for other purposes, remove if only for Toast
+                    val keyAttestationUiState by keyAttestationViewModel.uiState.collectAsStateWithLifecycle()
+                    val currentContext = LocalContext.current
 
-                    // Status and errors are now handled via uiState.status.
+                    LaunchedEffect(keyAttestationViewModel.shareEventFlow) {
+                        keyAttestationViewModel.shareEventFlow.collect { textToShare ->
+                            val sendIntent: Intent = Intent().apply {
+                                action = Intent.ACTION_SEND
+                                putExtra(Intent.EXTRA_TEXT, textToShare)
+                                type = "text/plain"
+                            }
+                            val shareIntent = Intent.createChooser(sendIntent, null)
+                            currentContext.startActivity(shareIntent)
+                        }
+                    }
+
+                    LaunchedEffect(keyAttestationViewModel.copyEventFlow) {
+                        keyAttestationViewModel.copyEventFlow.collect { textToCopy ->
+                            val clipboard =
+                                currentContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                            val clip = ClipData.newPlainText("Key Attestation Result", textToCopy)
+                            clipboard.setPrimaryClip(clip)
+                            Toast.makeText(currentContext, "Copied to clipboard", Toast.LENGTH_SHORT)
+                                .show()
+                        }
+                    }
 
                     KeyAttestationScreen(
-                        uiState = uiState,
+                        uiState = keyAttestationUiState,
                         onSelectedKeyTypeChange = {
                             keyAttestationViewModel.onSelectedKeyTypeChange(
                                 it
@@ -179,7 +203,9 @@ fun DeviceIntegrityApp(
                         },
                         onFetchNonceChallenge = { keyAttestationViewModel.fetchNonceChallenge() },
                         onGenerateKeyPair = { keyAttestationViewModel.generateKeyPair() },
-                        onRequestVerifyKeyAttestation = { keyAttestationViewModel.requestVerifyKeyAttestation() }
+                        onRequestVerifyKeyAttestation = { keyAttestationViewModel.requestVerifyKeyAttestation() },
+                        onCopyResults = { keyAttestationViewModel.onCopyResultsClicked() },
+                        onShareResults = { keyAttestationViewModel.onShareResultsClicked() }
                     )
                 }
                 composable(AppScreen.Menu.route) {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/AttestationResultFormatter.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/AttestationResultFormatter.kt
@@ -1,0 +1,14 @@
+package dev.keiji.deviceintegrity.ui.main.keyattestation
+
+object AttestationResultFormatter {
+    fun formatAttestationResults(items: List<AttestationInfoItem>): String {
+        return items.joinToString("\n") { item ->
+            val prefix = "".padStart(item.indentLevel * 2, ' ')
+            if (item.isHeader) {
+                "$prefix${item.label}"
+            } else {
+                "$prefix${item.label}: ${item.value}"
+            }
+        }
+    }
+}

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -41,22 +41,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KeyAttestationScreen(
-    uiState: KeyAttestationUiState,
+    uiState: KeyAttestationUiState, // uiState collected and passed from MainActivity
     onSelectedKeyTypeChange: (CryptoAlgorithm) -> Unit,
     onFetchNonceChallenge: () -> Unit,
     onGenerateKeyPair: () -> Unit,
     onRequestVerifyKeyAttestation: () -> Unit,
-    onCopyResults: () -> Unit,
-    onShareResults: () -> Unit,
+    onClickCopy: () -> Unit,
+    onClickShare: () -> Unit
 ) {
     val scrollState = rememberScrollState()
     var keyTypeExpanded by remember { mutableStateOf(false) }
-    val context = LocalContext.current
     val keyTypes = CryptoAlgorithm.values().toList()
 
     Column(
@@ -166,15 +166,15 @@ fun KeyAttestationScreen(
                                 MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.weight(1f)
                 )
-                if (uiState.verificationResultItems.isNotEmpty() && uiState.textToShare.isNotEmpty()) {
+                if (uiState.verificationResultItems.isNotEmpty()) {
                     Row {
-                        IconButton(onClick = onCopyResults) {
+                        IconButton(onClick = onClickCopy) {
                             Icon(
                                 imageVector = Icons.Filled.ContentCopy,
                                 contentDescription = "Copy Results"
                             )
                         }
-                        IconButton(onClick = onShareResults) {
+                        IconButton(onClick = onClickShare) {
                             Icon(
                                 imageVector = Icons.Filled.Share,
                                 contentDescription = "Share Results"
@@ -281,7 +281,7 @@ private fun KeyAttestationScreenPreview() {
         onFetchNonceChallenge = { System.out.println("Preview: Fetch Nonce/Challenge clicked") },
         onGenerateKeyPair = { System.out.println("Preview: Generate KeyPair clicked") },
         onRequestVerifyKeyAttestation = { System.out.println("Preview: Request Verify KeyAttestation clicked") },
-        onCopyResults = { System.out.println("Preview: Copy results clicked") },
-        onShareResults = { System.out.println("Preview: Share results clicked") }
+        onClickCopy = { System.out.println("Preview: onClickCopy called") },
+        onClickShare = { System.out.println("Preview: onClickShare called") }
     )
 }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,23 +14,31 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.draw.alpha
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
@@ -42,9 +51,12 @@ fun KeyAttestationScreen(
     onFetchNonceChallenge: () -> Unit,
     onGenerateKeyPair: () -> Unit,
     onRequestVerifyKeyAttestation: () -> Unit,
+    onCopyResults: () -> Unit,
+    onShareResults: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
     var keyTypeExpanded by remember { mutableStateOf(false) }
+    val context = LocalContext.current
     val keyTypes = CryptoAlgorithm.values().toList()
 
     Column(
@@ -139,15 +151,38 @@ fun KeyAttestationScreen(
 
         // Display general status
         if (uiState.status.isNotEmpty()) {
-            Text(
-                text = uiState.status,
-                style = if (uiState.verificationResultItems.isNotEmpty() && uiState.status.contains("successful", ignoreCase = true))
-                            MaterialTheme.typography.titleMedium
-                        else if (uiState.status.contains("failed", ignoreCase = true) || uiState.status.contains("error", ignoreCase = true))
-                            MaterialTheme.typography.titleMedium.copy(color = MaterialTheme.colorScheme.error)
-                        else
-                            MaterialTheme.typography.bodyMedium
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = uiState.status,
+                    style = if (uiState.verificationResultItems.isNotEmpty() && uiState.status.contains("successful", ignoreCase = true))
+                                MaterialTheme.typography.titleMedium
+                            else if (uiState.status.contains("failed", ignoreCase = true) || uiState.status.contains("error", ignoreCase = true))
+                                MaterialTheme.typography.titleMedium.copy(color = MaterialTheme.colorScheme.error)
+                            else
+                                MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                if (uiState.verificationResultItems.isNotEmpty() && uiState.textToShare.isNotEmpty()) {
+                    Row {
+                        IconButton(onClick = onCopyResults) {
+                            Icon(
+                                imageVector = Icons.Filled.ContentCopy,
+                                contentDescription = "Copy Results"
+                            )
+                        }
+                        IconButton(onClick = onShareResults) {
+                            Icon(
+                                imageVector = Icons.Filled.Share,
+                                contentDescription = "Share Results"
+                            )
+                        }
+                    }
+                }
+            }
             Spacer(modifier = Modifier.height(8.dp))
         }
 
@@ -245,6 +280,8 @@ private fun KeyAttestationScreenPreview() {
         onSelectedKeyTypeChange = { System.out.println("Preview: Key type changed to ${it.label}") },
         onFetchNonceChallenge = { System.out.println("Preview: Fetch Nonce/Challenge clicked") },
         onGenerateKeyPair = { System.out.println("Preview: Generate KeyPair clicked") },
-        onRequestVerifyKeyAttestation = { System.out.println("Preview: Request Verify KeyAttestation clicked") }
+        onRequestVerifyKeyAttestation = { System.out.println("Preview: Request Verify KeyAttestation clicked") },
+        onCopyResults = { System.out.println("Preview: Copy results clicked") },
+        onShareResults = { System.out.println("Preview: Share results clicked") }
     )
 }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -1,6 +1,5 @@
 package dev.keiji.deviceintegrity.ui.main.keyattestation
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,13 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Divider
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,11 +31,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
+import dev.keiji.deviceintegrity.ui.main.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -102,7 +95,9 @@ fun KeyAttestationScreen(
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = keyTypeExpanded)
                     },
                     colors = ExposedDropdownMenuDefaults.textFieldColors(),
-                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth()
                 )
                 ExposedDropdownMenu(
                     expanded = keyTypeExpanded,
@@ -170,13 +165,13 @@ fun KeyAttestationScreen(
                     Row {
                         IconButton(onClick = onClickCopy) {
                             Icon(
-                                imageVector = Icons.Filled.ContentCopy,
+                                painterResource(R.drawable.ic_content_copy),
                                 contentDescription = "Copy Results"
                             )
                         }
                         IconButton(onClick = onClickShare) {
                             Icon(
-                                imageVector = Icons.Filled.Share,
+                                painterResource(R.drawable.ic_share),
                                 contentDescription = "Share Results"
                             )
                         }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -16,6 +16,7 @@ data class KeyAttestationUiState(
     val status: String = "", // Keep for general status messages (e.g., "Fetching...", "Failed...")
     val verificationResultItems: List<AttestationInfoItem> = emptyList(), // New field for structured results
     val sessionId: String? = null,
-    val generatedKeyPairData: KeyPairData? = null
+    val generatedKeyPairData: KeyPairData? = null,
     // deviceInfoText and securityInfoText are removed as their content will be part of verificationResultItems
+    val textToShare: String = ""
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -16,7 +16,6 @@ data class KeyAttestationUiState(
     val status: String = "", // Keep for general status messages (e.g., "Fetching...", "Failed...")
     val verificationResultItems: List<AttestationInfoItem> = emptyList(), // New field for structured results
     val sessionId: String? = null,
-    val generatedKeyPairData: KeyPairData? = null,
+    val generatedKeyPairData: KeyPairData? = null
     // deviceInfoText and securityInfoText are removed as their content will be part of verificationResultItems
-    val textToShare: String = ""
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -1,10 +1,6 @@
 package dev.keiji.deviceintegrity.ui.main.keyattestation
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
-import android.content.Intent
-import android.widget.Toast
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.keiji.deviceintegrity.api.DeviceInfo
@@ -18,6 +14,7 @@ import dev.keiji.deviceintegrity.repository.contract.EcKeyPairRepository
 import dev.keiji.deviceintegrity.ui.main.util.Base64Utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -51,10 +51,6 @@ class KeyAttestationViewModel @Inject constructor(
     private val _copyEventChannel = Channel<String>()
     val copyEventFlow = _copyEventChannel.receiveAsFlow()
 
-    fun setTextToShare(text: String) {
-        _uiState.update { it.copy(textToShare = text) }
-    }
-
     fun onSelectedKeyTypeChange(newKeyType: CryptoAlgorithm) {
         _uiState.update { it.copy(selectedKeyType = newKeyType) }
     }
@@ -208,12 +204,10 @@ class KeyAttestationViewModel @Inject constructor(
                     resultItems.addAll(convertDeviceInfoToAttestationItems(response.deviceInfo))
                     resultItems.addAll(convertSecurityInfoToAttestationItems(response.securityInfo))
 
-                    val resultText = AttestationResultFormatter.formatAttestationResults(resultItems)
                     _uiState.update {
                         it.copy(
                             status = "Verification successful.", // General status
-                            verificationResultItems = resultItems,
-                            textToShare = resultText
+                            verificationResultItems = resultItems
                         )
                     }
                 } else {
@@ -330,19 +324,21 @@ class KeyAttestationViewModel @Inject constructor(
     }
 
     fun onCopyResultsClicked() {
-        val text = uiState.value.textToShare
-        if (text.isNotEmpty()) {
+        val items = uiState.value.verificationResultItems
+        if (items.isNotEmpty()) {
+            val textToCopy = AttestationResultFormatter.formatAttestationResults(items)
             viewModelScope.launch {
-                _copyEventChannel.send(text)
+                _copyEventChannel.send(textToCopy)
             }
         }
     }
 
     fun onShareResultsClicked() {
-        val text = uiState.value.textToShare
-        if (text.isNotEmpty()) {
+        val items = uiState.value.verificationResultItems
+        if (items.isNotEmpty()) {
+            val textToShare = AttestationResultFormatter.formatAttestationResults(items)
             viewModelScope.launch {
-                _shareEventChannel.send(text)
+                _shareEventChannel.send(textToShare)
             }
         }
     }


### PR DESCRIPTION
- Added copy and share icon buttons to the KeyAttestationScreen.
- Implemented event-driven copy and share logic in KeyAttestationViewModel and MainActivity.
- Removed unused showBottomSheet property from KeyAttestationUiState.