### PR TITLE
Adjust Key Attestation API response and update Android client

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyEcResponse.kt
@@ -60,25 +60,31 @@ data class AuthorizationList(
 )
 
 @Serializable
-data class VerifyEcResponse(
+data class AttestationInfo(
     @SerialName("attestation_security_level")
     val attestationSecurityLevel: Int,
     @SerialName("attestation_version")
     val attestationVersion: Int,
-    @SerialName("is_verified")
-    val isVerified: Boolean,
     @SerialName("keymint_security_level")
     val keymintSecurityLevel: Int,
     @SerialName("keymint_version")
     val keymintVersion: Int,
+    @SerialName("software_enforced_properties")
+    val softwareEnforcedProperties: AuthorizationList,
+    @SerialName("hardware_enforced_properties")
+    val hardwareEnforcedProperties: AuthorizationList?
+)
+
+@Serializable
+data class VerifyEcResponse(
+    @SerialName("is_verified")
+    val isVerified: Boolean,
     @SerialName("reason")
     val reason: String? = null,
     @SerialName("session_id")
     val sessionId: String,
-    @SerialName("software_enforced_properties")
-    val softwareEnforcedProperties: AuthorizationList,
-    @SerialName("tee_enforced_properties")
-    val teeEnforcedProperties: AuthorizationList?,
+    @SerialName("attestation_info")
+    val attestationInfo: AttestationInfo,
     @SerialName("device_info")
     val deviceInfo: DeviceInfo,
     @SerialName("security_info")

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -245,14 +245,17 @@ class KeyAttestationViewModel @Inject constructor(
         items.add(AttestationInfoItem("Session ID", response.sessionId))
         items.add(AttestationInfoItem("Is Verified", response.isVerified.toString()))
         response.reason?.let { items.add(AttestationInfoItem("Reason", it)) }
-        items.add(AttestationInfoItem("Attestation Version", response.attestationVersion.toString()))
-        items.add(AttestationInfoItem("Attestation Security Level", response.attestationSecurityLevel.toString()))
-        items.add(AttestationInfoItem("KeyMint Version", response.keymintVersion.toString()))
-        items.add(AttestationInfoItem("KeyMint Security Level", response.keymintSecurityLevel.toString()))
 
-        addAuthorizationListItems(items, "Software Enforced Properties", response.softwareEnforcedProperties)
-        response.teeEnforcedProperties?.let {
-            addAuthorizationListItems(items, "TEE Enforced Properties", it)
+        // Access properties from the new attestationInfo object
+        val attestationInfo = response.attestationInfo
+        items.add(AttestationInfoItem("Attestation Version", attestationInfo.attestationVersion.toString()))
+        items.add(AttestationInfoItem("Attestation Security Level", attestationInfo.attestationSecurityLevel.toString()))
+        items.add(AttestationInfoItem("KeyMint Version", attestationInfo.keymintVersion.toString()))
+        items.add(AttestationInfoItem("KeyMint Security Level", attestationInfo.keymintSecurityLevel.toString()))
+
+        addAuthorizationListItems(items, "Software Enforced Properties", attestationInfo.softwareEnforcedProperties)
+        attestationInfo.hardwareEnforcedProperties?.let {
+            addAuthorizationListItems(items, "Hardware Enforced Properties", it)
         }
 
         return items


### PR DESCRIPTION
Server:
- Renamed `tee_enforced_properties` to `hardware_enforced_properties`.
- Nested attestation-specific fields under `attestation_info`.
- Implemented Datastore saving for key attestation results, including payload and attestation data.

Android:
- Updated `VerifyEcResponse` data class to match the new server JSON structure, including the new `AttestationInfo` nested class.
- Adjusted `KeyAttestationViewModel` to correctly parse and display the new response structure.