### PR TITLE
Refactor: Rename key attestation verify endpoint from /ec to /signature

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
@@ -12,8 +12,8 @@ interface KeyAttestationVerifyApiClient {
     ): PrepareResponse
 
     // Ensure this path matches the server-side endpoint path
-    @POST("v1/verify/ec")
-    suspend fun verifyEc(
-        @Body requestBody: VerifyEcRequest
-    ): VerifyEcResponse
+    @POST("v1/verify/signature")
+    suspend fun verifySignature(
+        @Body requestBody: VerifySignatureRequest
+    ): VerifySignatureResponse
 }

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifySignatureRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifySignatureRequest.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
 @Serializable
-data class VerifyEcRequest(
+data class VerifySignatureRequest(
     @SerialName("session_id")
     val sessionId: String,
     @SerialName("signature")

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifySignatureResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifySignatureResponse.kt
@@ -76,7 +76,7 @@ data class AttestationInfo(
 )
 
 @Serializable
-data class VerifyEcResponse(
+data class VerifySignatureResponse(
     @SerialName("is_verified")
     val isVerified: Boolean,
     @SerialName("reason")

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -166,7 +166,7 @@ class KeyAttestationViewModel @Inject constructor(
                         currentKeyPairData.certificates.map { cert ->
                             Base64.Default.encode(cert.encoded)
                         }
-                    val request = VerifyEcRequest(
+                    val request = VerifySignatureRequest(
                         sessionId = currentSessionId,
                         signatureDataBase64UrlEncoded = signatureDataBase64UrlEncoded,
                         nonceBBase64UrlEncoded = nonceBBase64UrlEncoded,
@@ -192,7 +192,7 @@ class KeyAttestationViewModel @Inject constructor(
                             hasStrongbox = deviceSecurityStateProvider.hasStrongBox
                         )
                     )
-                    keyAttestationVerifyApiClient.verifyEc(request)
+                    keyAttestationVerifyApiClient.verifySignature(request)
                 }
 
                 if (response.isVerified) {
@@ -247,7 +247,7 @@ class KeyAttestationViewModel @Inject constructor(
         return items
     }
 
-    private fun buildVerificationResultList(response: VerifyEcResponse): MutableList<AttestationInfoItem> {
+    private fun buildVerificationResultList(response: VerifySignatureResponse): MutableList<AttestationInfoItem> {
         val items = mutableListOf<AttestationInfoItem>()
 
         items.add(AttestationInfoItem("Session ID", response.sessionId))

--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -633,17 +633,17 @@ def prepare_attestation():
         logger.error(f"Error in /prepare endpoint: {e}")
         return jsonify({"error": "An unexpected error occurred"}), 500
 
-@app.route('/v1/verify/ec', methods=['POST']) # Changed from Blueprint
-def verify_ec_attestation():
+@app.route('/v1/verify/signature', methods=['POST']) # Changed from Blueprint
+def verify_signature_attestation():
     """
-    Verifies the EC key attestation (mock implementation).
+    Verifies the Key Attestation Signature (mock implementation).
     Request body: { "session_id": "string", "signature": "string (Base64Encoded)", "nonce_b": "string (Base64Encoded)", "certificate_chain": ["string (Base64Encoded)"] }
     Response body: { "session_id": "string", "is_verified": false, "reason": "Mock implementation", "decoded_certificate_chain": { "mocked_detail": "This is a mock response for decoded certificate chain." }, "attestation_properties": { "mocked_software_enforced": {}, "mocked_tee_enforced": {} } }
     """
     try:
         data = request.get_json()
         if not data:
-            logger.warning("Verify EC request missing JSON payload.")
+            logger.warning("Verify Signature request missing JSON payload.")
             # Cannot get session_id if data is None, so pass a placeholder or handle differently
             store_key_attestation_result(
                 "unknown_session", "failed", "Missing JSON payload",
@@ -666,7 +666,7 @@ def verify_ec_attestation():
         payload_data_json_str = json.dumps(payload_data_for_datastore)
 
         if not session_id: # Explicitly check for session_id for storing results
-            logger.warning("Verify EC request missing session_id.")
+            logger.warning("Verify Signature request missing session_id.")
             store_key_attestation_result(
                 "missing_session_id", "failed", "Missing session_id in request",
                 payload_data_json_str, "{}"
@@ -675,7 +675,7 @@ def verify_ec_attestation():
 
 
         if not all([signature_b64, nonce_b_b64, certificate_chain_b64]):
-            logger.warning(f"Verify EC request for session '{session_id}' missing one or more required fields (signature, nonce_b, certificate_chain).")
+            logger.warning(f"Verify Signature request for session '{session_id}' missing one or more required fields (signature, nonce_b, certificate_chain).")
             store_key_attestation_result(
                 session_id, "failed", "Missing one or more required fields: signature, nonce_b, certificate_chain",
                 payload_data_json_str, "{}"
@@ -687,7 +687,7 @@ def verify_ec_attestation():
            not isinstance(nonce_b_b64, str) or \
            not isinstance(certificate_chain_b64, list) or \
            not all(isinstance(cert, str) for cert in certificate_chain_b64):
-            logger.warning(f"Verify EC request for session '{session_id}' has type mismatch for one or more fields.")
+            logger.warning(f"Verify Signature request for session '{session_id}' has type mismatch for one or more fields.")
             store_key_attestation_result(
                 session_id, "failed", "Type mismatch for one or more fields.",
                 payload_data_json_str, "{}"
@@ -695,7 +695,7 @@ def verify_ec_attestation():
             return jsonify({"error": "Type mismatch for one or more fields. Ensure session_id, signature, nonce_b are strings and certificate_chain is a list of strings."}), 400
 
         if not datastore_client:
-            logger.error("Datastore client not available for /verify/ec endpoint.")
+            logger.error("Datastore client not available for /verify/signature endpoint.")
             # Cannot store result if datastore is down.
             return jsonify({"error": "Datastore service not available"}), 503
 
@@ -817,7 +817,7 @@ def verify_ec_attestation():
             payload_data_json_str, attestation_data_json_str_success
         )
 
-        logger.info(f"Successfully verified EC key attestation for session_id: {session_id}")
+        logger.info(f"Successfully verified Key Attestation Signature for session_id: {session_id}")
         return jsonify(final_response), 200
 
     except ValueError as e: # Catch specific ValueErrors not caught by inner blocks
@@ -826,14 +826,14 @@ def verify_ec_attestation():
         current_session_id = locals().get("session_id", "unknown_session_value_error")
         payload_str = locals().get("payload_data_json_str", "{}")
         att_props_str = json.dumps(locals().get("attestation_properties") or {})
-        logger.warning(f"ValueError in /verify/ec for session {current_session_id}: {e}")
+        logger.warning(f"ValueError in /verify/signature for session {current_session_id}: {e}")
         store_key_attestation_result(current_session_id, "failed", str(e), payload_str, att_props_str)
         return jsonify({"error": str(e)}), 400
     except Exception as e: # Catch all other unexpected exceptions
         current_session_id = locals().get("session_id", "unknown_session_exception")
         payload_str = locals().get("payload_data_json_str", "{}")
         att_props_str = json.dumps(locals().get("attestation_properties") or {})
-        logger.error(f"Error in /verify/ec endpoint for session {current_session_id}: {e}", exc_info=True)
+        logger.error(f"Error in /verify/signature endpoint for session {current_session_id}: {e}", exc_info=True)
         store_key_attestation_result(current_session_id, "failed", "An unexpected error occurred.", payload_str, att_props_str)
         return jsonify({"error": "An unexpected error occurred"}), 500
 

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -51,11 +51,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /v1/verify/ec:
+  /v1/verify/signature:
     post:
-      summary: Verify EC Key Attestation
-      description: Verifies the EC Key Attestation (mock implementation).
-      operationId: verifyEcKeyAttestation
+      summary: Verify Key Attestation Signature
+      description: Verifies the Key Attestation Signature (mock implementation).
+      operationId: verifySignatureKeyAttestation
       tags:
         - KeyAttestationV1
       requestBody:
@@ -63,14 +63,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VerifyEcRequestBody'
+              $ref: '#/components/schemas/VerifySignatureRequestBody'
       responses:
         '200':
-          description: Successfully processed EC verification (mock response).
+          description: Successfully processed signature verification (mock response).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VerifyEcResponseBody'
+                $ref: '#/components/schemas/VerifySignatureResponseBody'
         '400':
           description: Bad Request (e.g., missing parameters).
           content:
@@ -111,7 +111,7 @@ components:
           format: byte
           description: Base64URL-encoded challenge.
           example: "Q2hhbGxlbmdlMTIzNDU2Nzg5MA=="
-    VerifyEcRequestBody:
+    VerifySignatureRequestBody:
       type: object
       required:
         - session_id
@@ -140,7 +140,7 @@ components:
             format: base64
           description: Array of standard Base64-encoded certificate strings.
           example: ["Y2VydDE=", "Y2VydDI="]
-    VerifyEcResponseBody:
+    VerifySignatureResponseBody:
       type: object
       required:
         - session_id


### PR DESCRIPTION
Refactor: Rename key attestation verify endpoint from /ec to /signature

This commit updates the server-side key attestation verification endpoint from `/v1/verify/ec` to `/v1/verify/signature`.

Changes include:
- Updated OpenAPI definition (`openapi.yaml`)
- Modified Flask server route and function name in `key_attestation.py`
- Updated Android Retrofit client interface (`KeyAttestationVerifyApiClient.kt`)
- Renamed Android request/response data classes (`VerifyEcRequest.kt` to `VerifySignatureRequest.kt` and `VerifyEcResponse.kt` to `VerifySignatureResponse.kt`) and updated their class names.