### PR TITLE
Refactor: Handle key attestation origin as integer

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifySignatureResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifySignatureResponse.kt
@@ -46,7 +46,7 @@ data class AuthorizationList(
     @SerialName("no_auth_required")
     val noAuthRequired: Boolean? = null,
     @SerialName("origin")
-    val origin: String? = null,
+    val origin: Int? = null,
     @SerialName("os_patch_level")
     val osPatchLevel: Int? = null,
     @SerialName("os_version")

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -286,7 +286,7 @@ class KeyAttestationViewModel @Inject constructor(
         }
         props.creationDatetime?.let { items.add(AttestationInfoItem("Creation Datetime", formatEpochMilliToISO8601(it), indentLevel = 1)) }
         props.algorithm?.let { items.add(AttestationInfoItem("Algorithm", it.toString(), indentLevel = 1)) }
-        props.origin?.let { items.add(AttestationInfoItem("Origin", it, indentLevel = 1)) }
+        props.origin?.let { items.add(AttestationInfoItem("Origin", it.toString(), indentLevel = 1)) }
         props.ecCurve?.let { items.add(AttestationInfoItem("EC Curve", it.toString(), indentLevel = 1)) }
         props.keySize?.let { items.add(AttestationInfoItem("Key Size", it.toString(), indentLevel = 1)) }
         props.purpose?.let { items.add(AttestationInfoItem("Purposes", it.joinToString(), indentLevel = 1)) }

--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -408,7 +408,7 @@ def parse_authorization_list(auth_list_sequence, attestation_version):
             elif tag_number == TAG_CREATION_DATETIME:
                 parsed_props['creation_datetime'] = int(value_component)
             elif tag_number == TAG_ORIGIN:
-                parsed_props['origin'] = str(value_component)
+                parsed_props['origin'] = int(value_component)
             elif tag_number == TAG_VENDOR_PATCH_LEVEL:
                 parsed_props['vendor_patch_level'] = int(value_component)
             elif tag_number == TAG_BOOT_PATCH_LEVEL:


### PR DESCRIPTION
Changes the 'origin' field in the key attestation data flow:
- Server-side: Parses 'origin' as an integer from ASN.1 data and serializes it as a number in the JSON response.
- Android-side: Deserializes 'origin' as an Integer and converts it to a String for display purposes in the UI.