### PR TITLE
fix: Correct OpenAPI example for module_hash

### DIFF
--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -267,7 +267,7 @@ TAG_EC_CURVE = 10
 TAG_RSA_PUBLIC_EXPONENT = 200
 TAG_MGF_DIGEST = 203
 
-TAG_ROLLBACK_RESISTANCE = 303  # v3+
+TAG_ROLLBACK_RESISTANCE = 303
 TAG_EARLY_BOOT_ONLY = 305
 
 TAG_ACTIVE_DATETIME = 400
@@ -278,10 +278,10 @@ TAG_USAGE_COUNT_LIMIT = 405
 TAG_NO_AUTH_REQUIRED = 503
 TAG_USER_AUTH_TYPE = 504
 TAG_AUTH_TIMEOUT = 505
-TAG_ALLOW_WHILE_ON_BODY = 506  # v3+
-TAG_TRUSTED_USER_PRESENCE_REQUIRED = 507  # v3+
-TAG_TRUSTED_CONFIRMATION_REQUIRED = 508  # v3+
-TAG_UNLOCKED_DEVICE_REQUIRED = 509  # v3+
+TAG_ALLOW_WHILE_ON_BODY = 506
+TAG_TRUSTED_USER_PRESENCE_REQUIRED = 507
+TAG_TRUSTED_CONFIRMATION_REQUIRED = 508
+TAG_UNLOCKED_DEVICE_REQUIRED = 509
 
 TAG_CREATION_DATETIME = 701
 TAG_ORIGIN = 702
@@ -300,6 +300,8 @@ TAG_ATTESTATION_ID_MODEL = 717
 TAG_VENDOR_PATCH_LEVEL = 718
 TAG_BOOT_PATCH_LEVEL = 719
 TAG_DEVICE_UNIQUE_ATTESTATION = 720
+TAG_ATTESTATION_ID_IMEI = 714
+TAG_ATTESTATION_ID_MEID = 715
 TAG_ATTESTATION_ID_SECOND_IMEI = 723
 TAG_MODULE_HASH = 724
 # ... and many more
@@ -429,6 +431,41 @@ def parse_authorization_list(auth_list_sequence, attestation_version):
                 parsed_props['module_hash'] = base64.urlsafe_b64encode(bytes(value_component)).decode()
             elif tag_number == TAG_ROOT_OF_TRUST:
                 parsed_props['root_of_trust'] = parse_root_of_trust(value_component)
+            elif tag_number == TAG_PADDING: # SET OF INTEGER
+                parsed_props['padding'] = [int(p) for p in value_component]
+            elif tag_number == TAG_ROLLBACK_RESISTANCE: # NULL
+                parsed_props['rollback_resistance'] = True
+            elif tag_number == TAG_EARLY_BOOT_ONLY: # NULL
+                parsed_props['early_boot_only'] = True
+            elif tag_number == TAG_ACTIVE_DATETIME: # INTEGER
+                parsed_props['active_datetime'] = int(value_component)
+            elif tag_number == TAG_ORIGINATION_EXPIRE_DATETIME: # INTEGER
+                parsed_props['origination_expire_datetime'] = int(value_component)
+            elif tag_number == TAG_USAGE_EXPIRE_DATETIME: # INTEGER
+                parsed_props['usage_expire_datetime'] = int(value_component)
+            elif tag_number == TAG_USAGE_COUNT_LIMIT: # INTEGER
+                parsed_props['usage_count_limit'] = int(value_component)
+            elif tag_number == TAG_USER_AUTH_TYPE: # INTEGER
+                # This is a bitmask, so keep it as an integer
+                parsed_props['user_auth_type'] = int(value_component)
+            elif tag_number == TAG_AUTH_TIMEOUT: # INTEGER
+                parsed_props['auth_timeout'] = int(value_component)
+            elif tag_number == TAG_ALLOW_WHILE_ON_BODY: # NULL
+                parsed_props['allow_while_on_body'] = True
+            elif tag_number == TAG_TRUSTED_USER_PRESENCE_REQUIRED: # NULL
+                parsed_props['trusted_user_presence_required'] = True
+            elif tag_number == TAG_TRUSTED_CONFIRMATION_REQUIRED: # NULL
+                parsed_props['trusted_confirmation_required'] = True
+            elif tag_number == TAG_UNLOCKED_DEVICE_REQUIRED: # NULL
+                parsed_props['unlocked_device_required'] = True
+            elif tag_number == TAG_ATTESTATION_ID_IMEI: # OCTET_STRING
+                parsed_props['attestation_id_imei'] = str(value_component)
+            elif tag_number == TAG_ATTESTATION_ID_MEID: # OCTET_STRING
+                parsed_props['attestation_id_meid'] = str(value_component)
+            elif tag_number == TAG_DEVICE_UNIQUE_ATTESTATION: # NULL
+                parsed_props['device_unique_attestation'] = True
+            elif tag_number == TAG_ATTESTATION_ID_SECOND_IMEI: # OCTET_STRING
+                parsed_props['attestation_id_second_imei'] = str(value_component)
             else:
                 logger.warning("Unknown tag:%d, %s" % (tag_number, value_component))
 

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -294,6 +294,144 @@ components:
           description: Vendor patch level.
           example: 20230201
           nullable: true
+        padding:
+          type: array
+          items:
+            type: integer
+            format: int32
+          description: Allowed padding modes (e.g., PKCS1, PSS, OAEP).
+          example: [1, 2]
+          nullable: true
+        rollback_resistance:
+          type: boolean # Representing NULL type, true if present
+          description: Indicates if rollback resistance is active. True if the tag is present.
+          example: true
+          nullable: true
+        early_boot_only:
+          type: boolean # Representing NULL type, true if present
+          description: Indicates if the key can only be used during early boot. True if the tag is present.
+          example: true
+          nullable: true
+        active_datetime:
+          type: integer
+          format: int64 # Epoch milliseconds
+          description: Date and time after which the key is valid.
+          example: 1678886400000
+          nullable: true
+        origination_expire_datetime:
+          type: integer
+          format: int64 # Epoch milliseconds
+          description: Date and time after which the key can no longer be used for origination (signing/encryption).
+          example: 1710508800000
+          nullable: true
+        usage_expire_datetime:
+          type: integer
+          format: int64 # Epoch milliseconds
+          description: Date and time after which the key can no longer be used for any purpose.
+          example: 1710508800000
+          nullable: true
+        usage_count_limit:
+          type: integer
+          format: int64
+          description: Maximum number of times the key can be used.
+          example: 1000
+          nullable: true
+        user_auth_type:
+          type: integer # Bitmask
+          format: int32
+          description: Bitmask of allowed user authentication types (e.g., fingerprint, password).
+          example: 3 # (Password | Fingerprint)
+          nullable: true
+        auth_timeout:
+          type: integer
+          format: int32 # Seconds
+          description: User authentication validity duration in seconds.
+          example: 300
+          nullable: true
+        allow_while_on_body:
+          type: boolean # Representing NULL type, true if present
+          description: Allows key use while the device is on-body. True if the tag is present.
+          example: true
+          nullable: true
+        trusted_user_presence_required:
+          type: boolean # Representing NULL type, true if present
+          description: Requires trusted user presence for key use. True if the tag is present.
+          example: true
+          nullable: true
+        trusted_confirmation_required:
+          type: boolean # Representing NULL type, true if present
+          description: Requires trusted confirmation for key use. True if the tag is present.
+          example: true
+          nullable: true
+        unlocked_device_required:
+          type: boolean # Representing NULL type, true if present
+          description: Requires the device to be unlocked for key use. True if the tag is present.
+          example: true
+          nullable: true
+        attestation_id_brand:
+          type: string
+          description: Brand of the device.
+          example: "Google"
+          nullable: true
+        attestation_id_device:
+          type: string
+          description: Device name.
+          example: "Pixel"
+          nullable: true
+        attestation_id_product:
+          type: string
+          description: Product name.
+          example: "raven"
+          nullable: true
+        attestation_id_serial:
+          type: string
+          description: Serial number of the device.
+          example: "SERIAL12345"
+          nullable: true
+        attestation_id_imei:
+          type: string
+          description: IMEI of the device.
+          example: "350000000000000"
+          nullable: true
+        attestation_id_meid:
+          type: string
+          description: MEID of the device.
+          example: "A0000000000000"
+          nullable: true
+        attestation_id_manufacturer:
+          type: string
+          description: Manufacturer of the device.
+          example: "Google"
+          nullable: true
+        attestation_id_model:
+          type: string
+          description: Model of the device.
+          example: "Pixel 6 Pro"
+          nullable: true
+        device_unique_attestation:
+          type: boolean # Representing NULL type, true if present
+          description: Indicates if the attestation is device-unique. True if the tag is present.
+          example: true
+          nullable: true
+        attestation_id_second_imei:
+          type: string
+          description: Second IMEI of the device, if available.
+          example: "350000000000001"
+          nullable: true
+        mgf_digest: # Was missing from existing OpenAPI but present in Python
+          type: array
+          items:
+            type: integer
+            format: int32
+          description: Allowed MGF digest algorithms for RSA PSS/OAEP.
+          example: [4] # SHA256
+          nullable: true
+        module_hash: # Was missing from existing OpenAPI but present in Python
+          type: string
+          format: byte # Base64URL Encoded
+          description: Hash of the KeyMint module if available.
+          example: "dGVzdF9oYXNo" # "test_hash" base64url encoded
+          nullable: true
       description: Contains properties of the key attestation. Fields are optional based on key characteristics.
 
     AttestationInfo:


### PR DESCRIPTION
Updated the example value for `module_hash` in
`server/key_attestation/openapi.yaml` to be a valid Base64URL
encoded string, resolving the `oas3-valid-schema-example` error.