### PR TITLE
Fix: Update module_hash example to valid Base64URL

### DIFF
--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -430,7 +430,7 @@ components:
           type: string
           format: byte # Base64URL Encoded
           description: Hash of the KeyMint module if available.
-          example: "someBase64UrlEncodedHashValue"
+          example: "dGVzdF9oYXNo"
           nullable: true
       description: Contains properties of the key attestation. Fields are optional based on key characteristics.
 


### PR DESCRIPTION
Updated the example value for `module_hash` in
`server/key_attestation/openapi.yaml` to be a valid Base64URL
encoded string, resolving the `oas3-valid-schema-example` error.