### PR TITLE
Refactor KeyAttestation error handling to use Repository pattern

### DIFF
--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/RepositoryModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/RepositoryModule.kt
@@ -14,6 +14,9 @@ import dev.keiji.deviceintegrity.repository.impl.KeyPairRepositoryImpl
 import dev.keiji.deviceintegrity.repository.impl.PlayIntegrityRepositoryImpl
 import kotlinx.coroutines.Dispatchers
 import javax.inject.Singleton
+import dev.keiji.deviceintegrity.api.keyattestation.KeyAttestationVerifyApiClient
+import dev.keiji.deviceintegrity.repository.contract.KeyAttestationRepository
+import dev.keiji.deviceintegrity.repository.impl.KeyAttestationRepositoryImpl
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -35,5 +38,13 @@ object RepositoryModule {
     @Singleton
     fun provideKeyPairRepository(): KeyPairRepository {
         return KeyPairRepositoryImpl(Dispatchers.IO)
+    }
+
+    @Provides
+    @Singleton
+    fun provideKeyAttestationRepository(
+        apiClient: KeyAttestationVerifyApiClient
+    ): KeyAttestationRepository {
+        return KeyAttestationRepositoryImpl(apiClient)
     }
 }

--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
@@ -1,0 +1,36 @@
+package dev.keiji.deviceintegrity.repository.contract
+
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareRequest
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
+import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureRequest
+import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureResponse
+import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
+import java.io.IOException
+
+interface KeyAttestationRepository {
+    /**
+     * Prepares the key attestation process by fetching a nonce and challenge from the server.
+     * @param requestBody The request containing the session ID.
+     * @return [PrepareResponse] containing the nonce and challenge.
+     * @throws ServerException if the server returns an error (e.g., HTTP error codes).
+     * @throws IOException if a network error occurs.
+     * @throws Exception for other unexpected errors.
+     */
+    @Throws(ServerException::class, IOException::class)
+    suspend fun prepare(
+        requestBody: PrepareRequest
+    ): PrepareResponse
+
+    /**
+     * Verifies the key attestation signature with the server.
+     * @param requestBody The request containing the signature, certificates, and device information.
+     * @return [VerifySignatureResponse] indicating the result of the verification.
+     * @throws ServerException if the server returns an error.
+     * @throws IOException if a network error occurs.
+     * @throws Exception for other unexpected errors.
+     */
+    @Throws(ServerException::class, IOException::class)
+    suspend fun verifySignature(
+        requestBody: VerifySignatureRequest
+    ): VerifySignatureResponse
+}

--- a/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyAttestationRepositoryImpl.kt
+++ b/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyAttestationRepositoryImpl.kt
@@ -1,0 +1,80 @@
+package dev.keiji.deviceintegrity.repository.impl
+
+import android.util.Log
+import dev.keiji.deviceintegrity.api.keyattestation.KeyAttestationVerifyApiClient
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareRequest
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
+import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureRequest
+import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureResponse
+import dev.keiji.deviceintegrity.repository.contract.KeyAttestationRepository
+import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
+import org.json.JSONObject
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+class KeyAttestationRepositoryImpl @Inject constructor(
+    private val apiClient: KeyAttestationVerifyApiClient
+) : KeyAttestationRepository {
+
+    companion object {
+        private const val TAG = "KeyAttestationRepo"
+    }
+
+    @Throws(ServerException::class, IOException::class)
+    override suspend fun prepare(
+        requestBody: PrepareRequest
+    ): PrepareResponse {
+        try {
+            return apiClient.prepare(requestBody)
+        } catch (e: HttpException) {
+            val errorBody = e.response()?.errorBody()?.string()
+            val errorMessage = parseErrorMessage(errorBody)
+            Log.w(TAG, "Prepare failed: HTTP ${e.code()}, Body: $errorBody", e)
+            throw ServerException(errorCode = e.code(), errorMessage = errorMessage, cause = e)
+        } catch (e: IOException) {
+            Log.w(TAG, "Prepare failed: Network error", e)
+            throw e // Re-throw IOException directly
+        } catch (e: Exception) {
+            Log.w(TAG, "Prepare failed: Unknown error", e)
+            throw IOException("An unknown error occurred during prepare: ${e.message}", e) // Wrap unknown errors in IOException or a more generic custom one if available
+        }
+    }
+
+    @Throws(ServerException::class, IOException::class)
+    override suspend fun verifySignature(
+        requestBody: VerifySignatureRequest
+    ): VerifySignatureResponse {
+        try {
+            return apiClient.verifySignature(requestBody)
+        } catch (e: HttpException) {
+            val errorBody = e.response()?.errorBody()?.string()
+            val errorMessage = parseErrorMessage(errorBody)
+            Log.w(TAG, "VerifySignature failed: HTTP ${e.code()}, Body: $errorBody", e)
+            throw ServerException(errorCode = e.code(), errorMessage = errorMessage, cause = e)
+        } catch (e: IOException) {
+            Log.w(TAG, "VerifySignature failed: Network error", e)
+            throw e // Re-throw IOException directly
+        } catch (e: Exception) {
+            Log.w(TAG, "VerifySignature failed: Unknown error", e)
+            throw IOException("An unknown error occurred during verifySignature: ${e.message}", e) // Wrap unknown errors
+        }
+    }
+
+    private fun parseErrorMessage(errorBody: String?): String? {
+        errorBody ?: return null
+        return try {
+            val jsonObj = JSONObject(errorBody)
+            // Try to get "message" or "error" field. If both are missing, optString returns empty string or null if key not found and no fallback.
+            // Prefer non-empty message over error, then fallback to null if neither provides useful info.
+            val message = jsonObj.optString("message", null)
+            if (!message.isNullOrEmpty()) return message
+            val error = jsonObj.optString("error", null)
+            if (!error.isNullOrEmpty()) return error
+            null // Return null if no meaningful message is found
+        } catch (jsonE: Exception) {
+            Log.w(TAG, "Failed to parse error JSON: $errorBody", jsonE)
+            null
+        }
+    }
+}

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -6,13 +6,15 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.keiji.deviceintegrity.api.DeviceInfo
 import dev.keiji.deviceintegrity.api.SecurityInfo
-import dev.keiji.deviceintegrity.api.keyattestation.*
+import dev.keiji.deviceintegrity.api.keyattestation.* // Import all keyattestation classes
 import dev.keiji.deviceintegrity.crypto.contract.Signer
 import dev.keiji.deviceintegrity.crypto.contract.qualifier.EC
 import dev.keiji.deviceintegrity.crypto.contract.qualifier.RSA
 import dev.keiji.deviceintegrity.provider.contract.DeviceInfoProvider
 import dev.keiji.deviceintegrity.provider.contract.DeviceSecurityStateProvider
 import dev.keiji.deviceintegrity.repository.contract.KeyPairRepository
+import dev.keiji.deviceintegrity.repository.contract.KeyAttestationRepository
+import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
 import dev.keiji.deviceintegrity.ui.main.util.Base64Utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -23,6 +25,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.IOException
 import java.security.SecureRandom
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -35,7 +38,7 @@ import kotlin.io.encoding.Base64
 @HiltViewModel
 class KeyAttestationViewModel @Inject constructor(
     private val keyPairRepository: KeyPairRepository,
-    private val keyAttestationVerifyApiClient: KeyAttestationVerifyApiClient,
+    private val keyAttestationRepository: KeyAttestationRepository,
     private val deviceInfoProvider: DeviceInfoProvider,
     private val deviceSecurityStateProvider: DeviceSecurityStateProvider,
     @EC private val ecSigner: Signer,
@@ -52,30 +55,27 @@ class KeyAttestationViewModel @Inject constructor(
     val copyEventFlow = _copyEventChannel.receiveAsFlow()
 
     fun onSelectedKeyTypeChange(newKeyType: CryptoAlgorithm) {
-        // Delete existing key pair and reset UI
         uiState.value.generatedKeyPairData?.keyAlias?.let { alias ->
             viewModelScope.launch {
                 try {
                     keyPairRepository.removeKeyPair(alias)
                 } catch (e: Exception) {
                     Log.e("KeyAttestationViewModel", "Failed to delete key pair", e)
-                    // Optionally update UI with error, though the main goal is to reset
                 }
             }
         }
         _uiState.update {
             it.copy(
                 selectedKeyType = newKeyType,
-                generatedKeyPairData = null, // Reset key pair data
-                verificationResultItems = emptyList(), // Clear verification results
-                status = "Key algorithm changed. Please generate a new key pair." // Inform user
+                generatedKeyPairData = null,
+                verificationResultItems = emptyList(),
+                status = "Key algorithm changed. Please generate a new key pair."
             )
         }
     }
 
     fun fetchNonceChallenge() {
         viewModelScope.launch {
-            // Delete existing key pair and reset UI before fetching nonce
             uiState.value.generatedKeyPairData?.keyAlias?.let { alias ->
                 try {
                     keyPairRepository.removeKeyPair(alias)
@@ -88,19 +88,17 @@ class KeyAttestationViewModel @Inject constructor(
                     status = "Fetching Nonce/Challenge...",
                     nonce = "",
                     challenge = "",
-                    generatedKeyPairData = null, // Reset key pair data
-                    verificationResultItems = emptyList() // Clear previous results
+                    generatedKeyPairData = null,
+                    verificationResultItems = emptyList()
                 )
             }
+
+            val newSessionId = UUID.randomUUID().toString()
+            _uiState.update { it.copy(sessionId = newSessionId) }
+
+            val request = PrepareRequest(sessionId = newSessionId)
             try {
-                val newSessionId = UUID.randomUUID().toString()
-                _uiState.update { it.copy(sessionId = newSessionId) }
-
-                val request = PrepareRequest(sessionId = newSessionId)
-                val response = withContext(Dispatchers.IO) {
-                    keyAttestationVerifyApiClient.prepare(request)
-                }
-
+                val response = keyAttestationRepository.prepare(request)
                 _uiState.update {
                     it.copy(
                         nonce = response.nonceBase64UrlEncoded,
@@ -108,10 +106,28 @@ class KeyAttestationViewModel @Inject constructor(
                         status = "Nonce/Challenge fetched successfully."
                     )
                 }
-            } catch (e: Exception) {
+            } catch (e: ServerException) {
+                Log.w("KeyAttestationViewModel", "ServerException fetching nonce/challenge", e)
+                val message = e.errorMessage ?: e.localizedMessage ?: "Unknown server error"
                 _uiState.update {
                     it.copy(
-                        status = "Failed to fetch Nonce/Challenge: ${e.message}",
+                        status = "Failed to fetch Nonce/Challenge: Server Error ${e.errorCode ?: ""}: $message",
+                        sessionId = null
+                    )
+                }
+            } catch (e: IOException) {
+                Log.w("KeyAttestationViewModel", "IOException fetching nonce/challenge", e)
+                _uiState.update {
+                    it.copy(
+                        status = "Failed to fetch Nonce/Challenge: Network Error: ${e.localizedMessage}",
+                        sessionId = null
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e("KeyAttestationViewModel", "Exception fetching nonce/challenge", e)
+                _uiState.update {
+                    it.copy(
+                        status = "Failed to fetch Nonce/Challenge: ${e.localizedMessage}",
                         sessionId = null
                     )
                 }
@@ -135,7 +151,7 @@ class KeyAttestationViewModel @Inject constructor(
                 return@launch
             }
 
-            try { // Single try block for the entire operation
+            try {
                 val decodedChallenge = withContext(Dispatchers.Default) {
                     Base64Utils.UrlSafeNoPadding.decode(currentChallenge)
                 }
@@ -148,14 +164,13 @@ class KeyAttestationViewModel @Inject constructor(
                     }
                 }
 
-                // keyPairDataResult is asserted non-null here as success (no exception) implies it.
                 _uiState.update {
                     it.copy(
                         generatedKeyPairData = keyPairDataResult,
                         status = "KeyPair generated successfully. Alias: ${keyPairDataResult.keyAlias}"
                     )
                 }
-            } catch (e: Exception) { // Single catch block for all exceptions
+            } catch (e: Exception) {
                 Log.e("KeyAttestationViewModel", "Failed to generate KeyPair", e)
                 _uiState.update { it.copy(status = "Failed to generate KeyPair: ${e.message}", generatedKeyPairData = null) }
             }
@@ -167,7 +182,7 @@ class KeyAttestationViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     status = "Verifying KeyAttestation...",
-                    verificationResultItems = emptyList() // Clear previous results
+                    verificationResultItems = emptyList()
                 )
             }
 
@@ -189,65 +204,64 @@ class KeyAttestationViewModel @Inject constructor(
                 return@launch
             }
 
-            try {
-                val response = withContext(Dispatchers.IO) {
-                    val nonceB = ByteArray(32)
-                    SecureRandom().nextBytes(nonceB)
-                    val decodedServerNonce = Base64Utils.UrlSafeNoPadding.decode(serverNonceB64Url)
-                    val dataToSign = decodedServerNonce + nonceB
-                    val privateKey = keyPair.private
+            val nonceB = ByteArray(32)
+            SecureRandom().nextBytes(nonceB)
+            val decodedServerNonce = Base64Utils.UrlSafeNoPadding.decode(serverNonceB64Url)
+            val dataToSign = decodedServerNonce + nonceB
+            val privateKey = keyPair.private
 
-                    val selectedSigner = when (uiState.value.selectedKeyType) {
-                        CryptoAlgorithm.EC -> ecSigner
-                        CryptoAlgorithm.RSA -> rsaSigner
-                        CryptoAlgorithm.ECDH -> throw IllegalStateException("ECDH is not supported for signing.")
-                    }
-                    val signatureData = selectedSigner.sign(dataToSign, privateKey)
-
-                    val signatureDataBase64UrlEncoded = Base64Utils.UrlSafeNoPadding.encode(signatureData)
-                    val nonceBBase64UrlEncoded = Base64Utils.UrlSafeNoPadding.encode(nonceB)
-                    val certificateChainBase64Encoded =
-                        currentKeyPairData.certificates.map { cert ->
-                            Base64.Default.encode(cert.encoded)
-                        }
-                    val request = VerifySignatureRequest(
-                        sessionId = currentSessionId,
-                        signatureDataBase64UrlEncoded = signatureDataBase64UrlEncoded,
-                        nonceBBase64UrlEncoded = nonceBBase64UrlEncoded,
-                        certificateChainBase64Encoded = certificateChainBase64Encoded,
-                        deviceInfo = DeviceInfo(
-                            brand = deviceInfoProvider.BRAND,
-                            model = deviceInfoProvider.MODEL,
-                            device = deviceInfoProvider.DEVICE,
-                            product = deviceInfoProvider.PRODUCT,
-                            manufacturer = deviceInfoProvider.MANUFACTURER,
-                            hardware = deviceInfoProvider.HARDWARE,
-                            board = deviceInfoProvider.BOARD,
-                            bootloader = deviceInfoProvider.BOOTLOADER,
-                            versionRelease = deviceInfoProvider.VERSION_RELEASE,
-                            sdkInt = deviceInfoProvider.SDK_INT,
-                            fingerprint = deviceInfoProvider.FINGERPRINT,
-                            securityPatch = deviceInfoProvider.SECURITY_PATCH
-                        ),
-                        securityInfo = SecurityInfo(
-                            isDeviceLockEnabled = deviceSecurityStateProvider.isDeviceLockEnabled,
-                            isBiometricsEnabled = deviceSecurityStateProvider.isBiometricsEnabled,
-                            hasClass3Authenticator = deviceSecurityStateProvider.hasClass3Authenticator,
-                            hasStrongbox = deviceSecurityStateProvider.hasStrongBox
-                        )
-                    )
-                    keyAttestationVerifyApiClient.verifySignature(request)
+            val selectedSigner = when (uiState.value.selectedKeyType) {
+                CryptoAlgorithm.EC -> ecSigner
+                CryptoAlgorithm.RSA -> rsaSigner
+                CryptoAlgorithm.ECDH -> {
+                    _uiState.update { it.copy(status = "ECDH is not supported for signing.") }
+                    return@launch
                 }
+            }
+            val signatureData = selectedSigner.sign(dataToSign, privateKey)
 
+            val signatureDataBase64UrlEncoded = Base64Utils.UrlSafeNoPadding.encode(signatureData)
+            val nonceBBase64UrlEncoded = Base64Utils.UrlSafeNoPadding.encode(nonceB)
+            val certificateChainBase64Encoded =
+                currentKeyPairData.certificates.map { cert ->
+                    Base64.Default.encode(cert.encoded)
+                }
+            val request = VerifySignatureRequest(
+                sessionId = currentSessionId,
+                signatureDataBase64UrlEncoded = signatureDataBase64UrlEncoded,
+                nonceBBase64UrlEncoded = nonceBBase64UrlEncoded,
+                certificateChainBase64Encoded = certificateChainBase64Encoded,
+                deviceInfo = DeviceInfo(
+                    brand = deviceInfoProvider.BRAND,
+                    model = deviceInfoProvider.MODEL,
+                    device = deviceInfoProvider.DEVICE,
+                    product = deviceInfoProvider.PRODUCT,
+                    manufacturer = deviceInfoProvider.MANUFACTURER,
+                    hardware = deviceInfoProvider.HARDWARE,
+                    board = deviceInfoProvider.BOARD,
+                    bootloader = deviceInfoProvider.BOOTLOADER,
+                    versionRelease = deviceInfoProvider.VERSION_RELEASE,
+                    sdkInt = deviceInfoProvider.SDK_INT,
+                    fingerprint = deviceInfoProvider.FINGERPRINT,
+                    securityPatch = deviceInfoProvider.SECURITY_PATCH
+                ),
+                securityInfo = SecurityInfo(
+                    isDeviceLockEnabled = deviceSecurityStateProvider.isDeviceLockEnabled,
+                    isBiometricsEnabled = deviceSecurityStateProvider.isBiometricsEnabled,
+                    hasClass3Authenticator = deviceSecurityStateProvider.hasClass3Authenticator,
+                    hasStrongbox = deviceSecurityStateProvider.hasStrongBox
+                )
+            )
+
+            try {
+                val response = keyAttestationRepository.verifySignature(request)
                 if (response.isVerified) {
                     val resultItems = buildVerificationResultList(response)
-                    // Append Device Info and Security Info to the main list
                     resultItems.addAll(convertDeviceInfoToAttestationItems(response.deviceInfo))
                     resultItems.addAll(convertSecurityInfoToAttestationItems(response.securityInfo))
-
                     _uiState.update {
                         it.copy(
-                            status = "Verification successful.", // General status
+                            status = "Verification successful.",
                             verificationResultItems = resultItems
                         )
                     }
@@ -256,9 +270,22 @@ class KeyAttestationViewModel @Inject constructor(
                         it.copy(status = "Verification failed. Reason: ${response.reason ?: "Unknown"}")
                     }
                 }
-
+            } catch (e: ServerException) {
+                Log.w("KeyAttestationViewModel", "ServerException verifying signature", e)
+                val message = e.errorMessage ?: e.localizedMessage ?: "Unknown server error"
+                _uiState.update {
+                    it.copy(status = "Failed to verify KeyAttestation: Server Error ${e.errorCode ?: ""}: $message")
+                }
+            } catch (e: IOException) {
+                Log.w("KeyAttestationViewModel", "IOException verifying signature", e)
+                _uiState.update {
+                    it.copy(status = "Failed to verify KeyAttestation: Network Error: ${e.localizedMessage}")
+                }
             } catch (e: Exception) {
-                _uiState.update { it.copy(status = "Failed to verify KeyAttestation: ${e.message}") }
+                Log.e("KeyAttestationViewModel", "Exception verifying signature", e)
+                _uiState.update {
+                    it.copy(status = "Failed to verify KeyAttestation: ${e.localizedMessage}")
+                }
             }
         }
     }
@@ -298,7 +325,6 @@ class KeyAttestationViewModel @Inject constructor(
         items.add(AttestationInfoItem("Is Verified", response.isVerified.toString()))
         response.reason?.let { items.add(AttestationInfoItem("Reason", it)) }
 
-        // Access properties from the new attestationInfo object
         val attestationInfo = response.attestationInfo
         items.add(AttestationInfoItem("Attestation Version", attestationInfo.attestationVersion.toString()))
         items.add(AttestationInfoItem("Attestation Security Level", attestationInfo.attestationSecurityLevel.toString()))
@@ -379,14 +405,9 @@ class KeyAttestationViewModel @Inject constructor(
 
     private fun formatEpochMilliToISO8601(epochMilli: Long): String {
         val date = Date(epochMilli)
-        // Replaced XXX with ZZZZZ for API level 23 compatibility.
-        // ZZZZZ produces a format like "GMT-07:00" or "UTC" if UTC.
-        // For UTC, it will be "UTC", to get "Z", one might need to replace "UTC" with "Z" manually.
-        // However, the requirement is ISO/IEC 8601, and "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ" is compliant.
         val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ", Locale.US)
         format.timeZone = TimeZone.getTimeZone("UTC")
         var formattedDate = format.format(date)
-        // Replace "UTC" with "Z" for the common ISO 8601 UTC designator
         if (formattedDate.endsWith("UTC")) {
             formattedDate = formattedDate.substring(0, formattedDate.length - 3) + "Z"
         }


### PR DESCRIPTION
Introduced KeyAttestationRepository to decouple KeyAttestationViewModel from direct API client usage and Retrofit-specific exceptions.

KeyAttestationRepositoryImpl now catches HttpExceptions and other network-related exceptions, throwing existing domain-specific exceptions (ServerException, IOException) instead.

KeyAttestationViewModel has been updated to use KeyAttestationRepository and handle these domain-specific exceptions, allowing for cleaner error display based on the server's response content.