### PR TITLE
Add generateEcdhKeyPair method to KeyPairRepository

### DIFF
--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyPairRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyPairRepository.kt
@@ -7,4 +7,5 @@ interface KeyPairRepository {
     suspend fun removeKeyPair(alias: String)
     suspend fun generateEcKeyPair(challenge: ByteArray): KeyPairData
     suspend fun generateRsaKeyPair(challenge: ByteArray): KeyPairData
+    suspend fun generateEcdhKeyPair(challenge: ByteArray): KeyPairData
 }


### PR DESCRIPTION
This commit introduces the `generateEcdhKeyPair` method to the `KeyPairRepository` interface and its implementation in `KeyPairRepositoryImpl`.

This method allows for the generation of Elliptic Curve Diffie-Hellman (ECDH) key pairs, which can be used for key agreement.

Key changes:
- Defined `generateEcdhKeyPair` in `KeyPairRepository.kt`.
- Implemented `generateEcdhKeyPair` in `KeyPairRepositoryImpl.kt`, using `KeyProperties.PURPOSE_AGREE_KEY`.
- Added corresponding unit tests in `KeyPairRepositoryImplTest.kt`.

Note: Instrumentation tests were added but could not be run in the automated environment due to the lack of a connected Android device or emulator. These tests should be run manually.