### PR TITLE
Refactor: Rename NonceB to ClientNonce in Key Attestation

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifySignatureRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifySignatureRequest.kt
@@ -10,9 +10,9 @@ data class VerifySignatureRequest(
     @SerialName("session_id")
     val sessionId: String,
     @SerialName("signature")
-    val signatureDataBase64UrlEncoded: String, // Assuming signature and nonce_b remain Base64URL encoded as per existing server code and OpenAPI spec for these fields
-    @SerialName("nonce_b")
-    val nonceBBase64UrlEncoded: String,
+    val signatureDataBase64UrlEncoded: String,
+    @SerialName("client_nonce")
+    val clientNonceBase64UrlEncoded: String,
     @SerialName("certificate_chain")
     val certificateChainBase64Encoded: List<String>,
     @SerialName("device_info")

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -288,10 +288,10 @@ class KeyAttestationViewModel @Inject constructor(
                 return@launch
             }
 
-            val nonceB = ByteArray(32)
-            SecureRandom().nextBytes(nonceB)
+            val clientNonce = ByteArray(32)
+            SecureRandom().nextBytes(clientNonce)
             val decodedServerNonce = Base64Utils.UrlSafeNoPadding.decode(serverNonceB64Url)
-            val dataToSign = decodedServerNonce + nonceB
+            val dataToSign = decodedServerNonce + clientNonce
             val privateKey = keyPair.private
 
             val selectedSigner = when (uiState.value.selectedKeyType) {
@@ -310,7 +310,7 @@ class KeyAttestationViewModel @Inject constructor(
             val signatureData = selectedSigner.sign(dataToSign, privateKey)
 
             val signatureDataBase64UrlEncoded = Base64Utils.UrlSafeNoPadding.encode(signatureData)
-            val nonceBBase64UrlEncoded = Base64Utils.UrlSafeNoPadding.encode(nonceB)
+            val clientNonceBase64UrlEncoded = Base64Utils.UrlSafeNoPadding.encode(clientNonce)
             val certificateChainBase64Encoded =
                 currentKeyPairData.certificates.map { cert ->
                     Base64.Default.encode(cert.encoded)
@@ -318,7 +318,7 @@ class KeyAttestationViewModel @Inject constructor(
             val request = VerifySignatureRequest(
                 sessionId = currentSessionId,
                 signatureDataBase64UrlEncoded = signatureDataBase64UrlEncoded,
-                nonceBBase64UrlEncoded = nonceBBase64UrlEncoded,
+                clientNonceBase64UrlEncoded = clientNonceBase64UrlEncoded,
                 certificateChainBase64Encoded = certificateChainBase64Encoded,
                 deviceInfo = DeviceInfo(
                     brand = deviceInfoProvider.BRAND,

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -128,7 +128,7 @@ components:
           format: byte
           description: Base64-URL-encoded signature.
           example: "U2lnbmVkRGF0YTEyMzQ1Njc4OTA="
-        nonce_b:
+        client_nonce:
           type: string
           format: byte
           description: Base64-encoded second nonce from client.


### PR DESCRIPTION
- I renamed the client-generated nonce parameter from `nonce_b` to `client_nonce` in the Key Attestation server API (OpenAPI spec and Python code).
- I updated the Android client (KeyAttestationViewModel and VerifySignatureRequest data class) to generate and send this nonce as `clientNonce` / `clientNonceBase64UrlEncoded` (serialized as `client_nonce`).
- I ensured the server-side nonce (`serverNonceB64Url` in client, `nonce` in server's PrepareResponseBody) remains unchanged.
- OpenAPI linting for Key Attestation passed after changes.