### PR TITLE
feat: Adjust KeyAttestation ECDH handling based on API level

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import android.os.Build
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.keiji.deviceintegrity.ui.main.InfoItem
@@ -122,7 +123,8 @@ fun KeyAttestationScreen(
                                 onSelectedKeyTypeChange(algorithm)
                                 keyTypeExpanded = false
                             },
-                            enabled = uiState.isStep2KeySelectionEnabled
+                            enabled = uiState.isStep2KeySelectionEnabled &&
+                                    !(algorithm == CryptoAlgorithm.ECDH && Build.VERSION.SDK_INT < Build.VERSION_CODES.S)
                         )
                     }
                 }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -16,6 +16,7 @@ import dev.keiji.deviceintegrity.repository.contract.KeyPairRepository
 import dev.keiji.deviceintegrity.repository.contract.KeyAttestationRepository
 import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
 import dev.keiji.deviceintegrity.ui.main.InfoItem
+import android.os.Build
 import dev.keiji.deviceintegrity.ui.main.common.KEY_ATTESTATION_DELAY_MS
 import dev.keiji.deviceintegrity.ui.main.playintegrity.PlayIntegrityProgressConstants
 import dev.keiji.deviceintegrity.ui.main.util.Base64Utils
@@ -197,7 +198,12 @@ class KeyAttestationViewModel @Inject constructor(
                     when (uiState.value.selectedKeyType) {
                         CryptoAlgorithm.RSA -> keyPairRepository.generateRsaKeyPair(decodedChallenge)
                         CryptoAlgorithm.EC -> keyPairRepository.generateEcKeyPair(decodedChallenge)
-                        CryptoAlgorithm.ECDH -> throw UnsupportedOperationException("ECDH key generation is not yet implemented.")
+                        CryptoAlgorithm.ECDH -> {
+                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                                throw UnsupportedOperationException("このデバイスのAndroidのバージョンは構成証明付きのECDH鍵ペアに対応していません")
+                            }
+                            keyPairRepository.generateEcdhKeyPair(decodedChallenge)
+                        }
                     }
                 }
 


### PR DESCRIPTION
- Disable ECDH option in dropdown for API < 31.
- Show unsupported message if ECDH selected on API < 31.
- Enable ECDH key pair generation for API >= 31.