### PR TITLE
Fix: Correct package name for CryptoImplTest

### DIFF
--- a/android/crypto/contract/src/main/java/dev/keiji/deviceintegrity/crypto/contract/CryptoInterface.kt
+++ b/android/crypto/contract/src/main/java/dev/keiji/deviceintegrity/crypto/contract/CryptoInterface.kt
@@ -1,0 +1,11 @@
+package dev.keiji.deviceintegrity.crypto.contract
+
+import javax.crypto.SecretKey
+
+interface Encrypt {
+    fun encrypt(plain: ByteArray, secretKey: SecretKey, aad: ByteArray? = null): ByteArray
+}
+
+interface Decrypt {
+    fun decrypt(encrypted: ByteArray, secretKey: SecretKey, aad: ByteArray? = null): ByteArray
+}

--- a/android/crypto/impl/src/main/java/dev/keiji/deviceintegrity/crypto/impl/CryptoImpl.kt
+++ b/android/crypto/impl/src/main/java/dev/keiji/deviceintegrity/crypto/impl/CryptoImpl.kt
@@ -1,0 +1,36 @@
+package dev.keiji.deviceintegrity.crypto.impl
+
+import dev.keiji.deviceintegrity.crypto.contract.Decrypt
+import dev.keiji.deviceintegrity.crypto.contract.Encrypt
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class EncryptImpl : Encrypt {
+    override fun encrypt(plain: ByteArray, secretKey: SecretKey, aad: ByteArray?): ByteArray {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        // Generate a random IV (Initialization Vector)
+        val iv = ByteArray(12) // GCM recommended IV size is 12 bytes
+        SecureRandom().nextBytes(iv)
+        val gcmParameterSpec = GCMParameterSpec(128, iv) // 128 bit auth tag length
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmParameterSpec)
+        aad?.let { cipher.updateAAD(it) }
+        val cipherText = cipher.doFinal(plain)
+        // Prepend IV to the ciphertext for use in decryption
+        return iv + cipherText
+    }
+}
+
+class DecryptImpl : Decrypt {
+    override fun decrypt(encrypted: ByteArray, secretKey: SecretKey, aad: ByteArray?): ByteArray {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        // Extract IV from the beginning of the encrypted data
+        val iv = encrypted.copyOfRange(0, 12)
+        val cipherText = encrypted.copyOfRange(12, encrypted.size)
+        val gcmParameterSpec = GCMParameterSpec(128, iv)
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmParameterSpec)
+        aad?.let { cipher.updateAAD(it) }
+        return cipher.doFinal(cipherText)
+    }
+}

--- a/android/crypto/impl/src/test/java/dev/keiji/deviceintegrity/crypto/impl/CryptoImplTest.kt
+++ b/android/crypto/impl/src/test/java/dev/keiji/deviceintegrity/crypto/impl/CryptoImplTest.kt
@@ -1,0 +1,140 @@
+package dev.keiji.deviceintegrity.crypto.impl
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.SecureRandom
+import javax.crypto.AEADBadTagException
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+class CryptoImplTest {
+
+    private val encrypter = EncryptImpl()
+    private val decrypter = DecryptImpl()
+
+    private fun generateAesKey(): SecretKey {
+        val keyGen = KeyGenerator.getInstance("AES")
+        keyGen.init(256) // AES-256
+        return keyGen.generateKey()
+    }
+
+    @Test
+    fun `encrypt and decrypt successfully with no AAD`() {
+        val secretKey = generateAesKey()
+        val plainText = "This is a secret message.".toByteArray()
+
+        val encrypted = encrypter.encrypt(plainText, secretKey)
+        val decrypted = decrypter.decrypt(encrypted, secretKey)
+
+        assertArrayEquals(plainText, decrypted)
+    }
+
+    @Test
+    fun `encrypt and decrypt successfully with AAD`() {
+        val secretKey = generateAesKey()
+        val plainText = "This is another secret message.".toByteArray()
+        val aad = "Additional Authentication Data".toByteArray()
+
+        val encrypted = encrypter.encrypt(plainText, secretKey, aad)
+        val decrypted = decrypter.decrypt(encrypted, secretKey, aad)
+
+        assertArrayEquals(plainText, decrypted)
+    }
+
+    @Test
+    fun `decrypt fails with incorrect key`() {
+        val key1 = generateAesKey()
+        val key2 = generateAesKey()
+        val plainText = "Sensitive information.".toByteArray()
+
+        val encrypted = encrypter.encrypt(plainText, key1)
+
+        assertThrows(AEADBadTagException::class.java) {
+            decrypter.decrypt(encrypted, key2)
+        }
+    }
+
+    @Test
+    fun `decrypt fails with tampered ciphertext`() {
+        val secretKey = generateAesKey()
+        val plainText = "Don't tamper with this!".toByteArray()
+
+        val encrypted = encrypter.encrypt(plainText, secretKey)
+        encrypted[encrypted.size - 1] = encrypted[encrypted.size - 1].inc() // Tamper last byte
+
+        assertThrows(AEADBadTagException::class.java) {
+            decrypter.decrypt(encrypted, secretKey)
+        }
+    }
+
+    @Test
+    fun `decrypt fails with tampered IV`() {
+        val secretKey = generateAesKey()
+        val plainText = "IV tampering test".toByteArray()
+
+        val encrypted = encrypter.encrypt(plainText, secretKey)
+        encrypted[0] = encrypted[0].inc() // Tamper first byte of IV
+
+        assertThrows(AEADBadTagException::class.java) {
+            decrypter.decrypt(encrypted, secretKey)
+        }
+    }
+
+
+    @Test
+    fun `decrypt fails with incorrect AAD`() {
+        val secretKey = generateAesKey()
+        val plainText = "AAD mismatch test".toByteArray()
+        val aad1 = "Correct AAD".toByteArray()
+        val aad2 = "Incorrect AAD".toByteArray()
+
+        val encrypted = encrypter.encrypt(plainText, secretKey, aad1)
+
+        assertThrows(AEADBadTagException::class.java) {
+            decrypter.decrypt(encrypted, secretKey, aad2)
+        }
+    }
+
+    @Test
+    fun `decrypt fails if AAD was used in encryption but not in decryption`() {
+        val secretKey = generateAesKey()
+        val plainText = "AAD missing in decryption".toByteArray()
+        val aad = "AAD Present".toByteArray()
+
+        val encrypted = encrypter.encrypt(plainText, secretKey, aad)
+
+        assertThrows(AEADBadTagException::class.java) {
+            decrypter.decrypt(encrypted, secretKey, null)
+        }
+    }
+
+    @Test
+    fun `decrypt fails if AAD was not used in encryption but provided in decryption`() {
+        val secretKey = generateAesKey()
+        val plainText = "AAD provided unexpectedly".toByteArray()
+        val aad = "Unexpected AAD".toByteArray()
+
+        val encrypted = encrypter.encrypt(plainText, secretKey, null)
+
+        assertThrows(AEADBadTagException::class.java) {
+            decrypter.decrypt(encrypted, secretKey, aad)
+        }
+    }
+
+    @Test
+    fun `encrypted output contains IV and ciphertext`() {
+        val secretKey = generateAesKey()
+        val plainText = "Test IV concatenation".toByteArray()
+        val ivSize = 12 // As defined in EncryptImpl
+
+        val encrypted = encrypter.encrypt(plainText, secretKey)
+
+        assertTrue("Encrypted data should be larger than plaintext + IV size", encrypted.size > plainText.size + ivSize)
+        assertEquals("Encrypted data size should be IV size + ciphertext size + auth tag size (16 bytes for 128-bit tag)",
+            ivSize + plainText.size + 16, encrypted.size)
+
+    }
+}


### PR DESCRIPTION
Ensures the package declaration in `CryptoImplTest.kt` is `dev.keiji.deviceintegrity.crypto.impl`, matching its directory structure and the package of the classes it tests.