### PR TITLE
KeyAttestation APIのprepare関連の名称をprepareSignatureに統一しました（ViewModelの修正も含みます）

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
@@ -6,9 +6,9 @@ import retrofit2.http.POST
 interface KeyAttestationVerifyApiClient {
 
     // Ensure this path matches the server-side endpoint path
-    @POST("v1/prepare")
-    suspend fun prepare(
-        @Body requestBody: PrepareRequest
+    @POST("v1/prepare/signature")
+    suspend fun prepareSignature(
+        @Body requestBody: PrepareSignatureRequest
     ): PrepareResponse
 
     // Ensure this path matches the server-side endpoint path

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareSignatureRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareSignatureRequest.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
 @Serializable
-data class PrepareRequest(
+data class PrepareSignatureRequest(
     @SerialName("session_id")
     val sessionId: String
 )

--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
@@ -18,7 +18,7 @@ interface KeyAttestationRepository {
      */
     @Throws(ServerException::class, IOException::class)
     suspend fun prepareSignature(
-        requestBody: PrepareRequest
+        requestBody: PrepareSignatureRequest
     ): PrepareResponse
 
     /**

--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
@@ -1,6 +1,6 @@
 package dev.keiji.deviceintegrity.repository.contract
 
-import dev.keiji.deviceintegrity.api.keyattestation.PrepareRequest
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareSignatureRequest
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
 import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureRequest
 import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureResponse
@@ -17,7 +17,7 @@ interface KeyAttestationRepository {
      * @throws Exception for other unexpected errors.
      */
     @Throws(ServerException::class, IOException::class)
-    suspend fun prepare(
+    suspend fun prepareSignature(
         requestBody: PrepareRequest
     ): PrepareResponse
 

--- a/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyAttestationRepositoryImpl.kt
+++ b/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyAttestationRepositoryImpl.kt
@@ -2,7 +2,7 @@ package dev.keiji.deviceintegrity.repository.impl
 
 import android.util.Log
 import dev.keiji.deviceintegrity.api.keyattestation.KeyAttestationVerifyApiClient
-import dev.keiji.deviceintegrity.api.keyattestation.PrepareRequest
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareSignatureRequest
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
 import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureRequest
 import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureResponse
@@ -22,11 +22,11 @@ class KeyAttestationRepositoryImpl @Inject constructor(
     }
 
     @Throws(ServerException::class, IOException::class)
-    override suspend fun prepare(
-        requestBody: PrepareRequest
+    override suspend fun prepareSignature(
+        requestBody: PrepareSignatureRequest
     ): PrepareResponse {
         try {
-            return apiClient.prepare(requestBody)
+            return apiClient.prepareSignature(requestBody)
         } catch (e: HttpException) {
             val errorBody = e.response()?.errorBody()?.string()
             val errorMessage = parseErrorMessage(errorBody)

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -123,9 +123,9 @@ class KeyAttestationViewModel @Inject constructor(
             val newSessionId = UUID.randomUUID().toString()
             _uiState.update { it.copy(sessionId = newSessionId) }
 
-            val request = PrepareRequest(sessionId = newSessionId)
+            val request = PrepareSignatureRequest(sessionId = newSessionId)
             try {
-                val response = keyAttestationRepository.prepare(request)
+                val response = keyAttestationRepository.prepareSignature(request)
                 _uiState.update {
                     it.copy(
                         nonce = response.nonceBase64UrlEncoded,

--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -647,10 +647,10 @@ def store_key_attestation_result(session_id, result, reason, payload_data_json_s
 
 # --- Endpoints ---
 
-@app.route('/v1/prepare', methods=['POST']) # Changed from Blueprint
-def prepare_attestation():
+@app.route('/v1/prepare/signature', methods=['POST']) # Changed from Blueprint
+def prepare_signature_attestation():
     """
-    Prepares for key attestation by generating a nonce and challenge.
+    Prepares for key attestation signature by generating a nonce and challenge.
     Request body: { "session_id": "string" }
     Response body: { "nonce": "string (Base64URLEncoded)", "challenge": "string (Base64URLEncoded)" }
     """

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -18,11 +18,11 @@ servers:
     description: Key Attestation Service Base URL
 
 paths:
-  /v1/prepare:
+  /v1/prepare/signature:
     post:
-      summary: Prepare Key Attestation
-      description: Generates a nonce and challenge for Key Attestation.
-      operationId: prepareKeyAttestation
+      summary: Prepare Key Attestation Signature
+      description: Generates a nonce and challenge for Key Attestation Signature.
+      operationId: prepareSignatureKeyAttestation
       tags:
         - KeyAttestationV1
       requestBody:


### PR DESCRIPTION
KeyAttestation APIのprepare関連の名称をprepareSignatureに統一しました（ViewModelの修正も含みます）。

サーバー側のエンドポイントを `/v1/prepare` から `/v1/prepare/signature` に変更しました。
OpenAPI定義、Flask関数名も同様に変更しました。

Android側では、以下の対応を行いました。
- `KeyAttestationVerifyApiClient`のメソッド名を`prepareSignature`に変更し、パスも更新しました。
- `PrepareRequest`を`PrepareSignatureRequest`にリネームしました（ファイル名も同様です）。
- `KeyAttestationRepository`および`KeyAttestationRepositoryImpl`のメソッド名を`prepareSignature`に変更し、引数型も更新しました。
- `KeyAttestationViewModel`で`prepareSignature`を呼び出すように修正しました。

ビルドの問題が継続したため、ローカルでのビルド確認はスキップしました。