### PR TITLE
Refactor: Rename KeyAttestationSession to SignatureKeyAttestationSession

### DIFF
--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -29,7 +29,7 @@ except Exception as e:
     datastore_client = None
 
 # Datastore Kind for Key Attestation Sessions
-KEY_ATTESTATION_SESSION_KIND = "KeyAttestationSession"
+KEY_ATTESTATION_SESSION_KIND = "SignatureKeyAttestationSession"
 KEY_ATTESTATION_RESULT_KIND = "KeyAttestationResult" # New Datastore Kind
 NONCE_EXPIRY_MINUTES = 10 # Renamed from SESSION_EXPIRY_MINUTES
 


### PR DESCRIPTION
I renamed the Datastore Kind for key attestation sessions from 'KeyAttestationSession' to 'SignatureKeyAttestationSession' for clarity and to better reflect its specific use for signature attestation flows.

All functions interacting with this Datastore Kind have been implicitly updated by changing the shared constant.