### PR TITLE
Here's how I'll implement server-side key agreement attestation:

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
@@ -16,4 +16,9 @@ interface KeyAttestationVerifyApiClient {
     suspend fun verifySignature(
         @Body requestBody: VerifySignatureRequest
     ): VerifySignatureResponse
+
+    @POST("v1/prepare/agreement")
+    suspend fun prepareAgreement(
+        @Body requestBody: PrepareAgreementRequest
+    ): PrepareAgreementResponse
 }

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareAgreementRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareAgreementRequest.kt
@@ -1,0 +1,10 @@
+package dev.keiji.deviceintegrity.api.keyattestation
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+@Serializable
+data class PrepareAgreementRequest(
+    @SerialName("session_id")
+    val sessionId: String
+)

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareAgreementResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareAgreementResponse.kt
@@ -1,0 +1,12 @@
+package dev.keiji.deviceintegrity.api.keyattestation
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+@Serializable
+data class PrepareAgreementResponse(
+    @SerialName("salt")
+    val saltBase64UrlEncoded: String,
+    @SerialName("challenge")
+    val challengeBase64UrlEncoded: String
+)

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -84,6 +84,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /v1/prepare/agreement:
+    post:
+      summary: Prepare Key Attestation Agreement
+      description: Generates a salt and challenge for Key Attestation Agreement.
+      operationId: prepareAgreementKeyAttestation
+      tags:
+        - KeyAttestationV1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrepareAgreementRequestBody'
+      responses:
+        '200':
+          description: Successfully generated salt and challenge.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrepareAgreementResponseBody'
+        '400':
+          description: Bad Request (e.g., missing session_id).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     PrepareRequestBody:
@@ -111,6 +144,31 @@ components:
           format: byte
           description: Base64URL-encoded challenge.
           example: "Q2hhbGxlbmdlMTIzNDU2Nzg5MA=="
+    PrepareAgreementRequestBody:
+      type: object
+      required:
+        - session_id
+      properties:
+        session_id:
+          type: string
+          description: Client session ID.
+          example: "session-abcde-67890"
+    PrepareAgreementResponseBody:
+      type: object
+      required:
+        - salt
+        - challenge
+      properties:
+        salt:
+          type: string
+          format: byte
+          description: Base64URL-encoded salt.
+          example: "U2FsdGVkX19Tb21lU2FsdFZhbHVl"
+        challenge:
+          type: string
+          format: byte
+          description: Base64URL-encoded challenge.
+          example: "Q2hhbGxlbmdlU3RyaW5nSGVyZQ=="
     VerifySignatureRequestBody:
       type: object
       required:


### PR DESCRIPTION
- I'll add the API endpoint `/v1/prepare/agreement`.
- Then, I'll implement the logic for storing and retrieving agreement sessions.
- Next, I'll update the OpenAPI definition.
- Finally, I'll add the Android client classes and Retrofit interface method for the new endpoint.