### PR TITLE
feat: Include ECDH public key in KeyAttestation agreement

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareAgreementResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/PrepareAgreementResponse.kt
@@ -8,5 +8,7 @@ data class PrepareAgreementResponse(
     @SerialName("salt")
     val saltBase64UrlEncoded: String,
     @SerialName("challenge")
-    val challengeBase64UrlEncoded: String
+    val challengeBase64UrlEncoded: String,
+    @SerialName("public_key")
+    val publicKeyBase64UrlEncoded: String
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -55,11 +55,11 @@ fun KeyAttestationScreen(
     val isHorizontalProgressVisible = uiState.progressValue > PlayIntegrityProgressConstants.NO_PROGRESS && uiState.progressValue < PlayIntegrityProgressConstants.FULL_PROGRESS
 
     val step2Label = when (uiState.selectedKeyType) {
-        CryptoAlgorithm.ECDH -> "Step 2. サーバーからSalt/Challengeを取得"
+        CryptoAlgorithm.ECDH -> "Step 2. サーバーからSalt/Challenge/PublicKeyを取得" // Updated for ECDH
         else -> "Step 2. サーバーからNonce/Challengeを取得"
     }
     val step2ButtonText = when (uiState.selectedKeyType) {
-        CryptoAlgorithm.ECDH -> "Fetch Salt/Challenge"
+        CryptoAlgorithm.ECDH -> "Fetch Salt/Challenge/PublicKey" // Updated for ECDH
         else -> "Fetch Nonce/Challenge"
     }
     val saltOrNonceLabel = when (uiState.selectedKeyType) {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -62,7 +62,7 @@ fun KeyAttestationScreen(
         CryptoAlgorithm.ECDH -> "Fetch Salt/Challenge/PublicKey" // Updated for ECDH
         else -> "Fetch Nonce/Challenge"
     }
-    val saltOrNonceLabel = when (uiState.selectedKeyType) {
+    val nonceOrSaltLabel = when (uiState.selectedKeyType) { // Renamed from saltOrNonceLabel
         CryptoAlgorithm.ECDH -> "Salt"
         else -> "Nonce"
     }
@@ -135,8 +135,8 @@ fun KeyAttestationScreen(
         }
 
         Spacer(modifier = Modifier.height(8.dp))
-        if (uiState.isSaltOrNonceVisible) { // Use new UiState property
-            Text(text = "$saltOrNonceLabel: ${uiState.saltOrNonce}") // Use new UiState property and dynamic label
+        if (uiState.isNonceOrSaltVisible) { // Use new UiState property - Renamed from isSaltOrNonceVisible
+            Text(text = "$nonceOrSaltLabel: ${uiState.nonceOrSalt}") // Use new UiState property and dynamic label - Renamed saltOrNonce
         }
         Spacer(modifier = Modifier.height(8.dp))
         if (uiState.isChallengeVisible) {
@@ -242,7 +242,7 @@ private fun KeyAttestationScreenPreview() {
     )
     KeyAttestationScreen(
         uiState = KeyAttestationUiState(
-            saltOrNonce = "PREVIEW_SALT_OR_NONCE_67890", // Updated field name
+            nonceOrSalt = "PREVIEW_NONCE_OR_SALT_67890", // Renamed field saltOrNonce
             challenge = "PREVIEW_CHALLENGE_ABCDE",
             selectedKeyType = CryptoAlgorithm.RSA, // Example: RSA selected
             status = "Verification successful.",

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -129,7 +129,7 @@ fun KeyAttestationScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(ButtonHeight),
-            enabled = uiState.isStep2FetchSaltOrNonceChallengeEnabled // Use new UiState property
+            enabled = uiState.isStep2FetchNonceOrSaltChallengeEnabled // Use new UiState property - Renamed
         ) {
             Text(text = step2ButtonText)
         }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -25,8 +25,8 @@ data class KeyAttestationUiState(
     // Step 1 is now Key Selection, enabled if not loading
     val isStep1KeySelectionEnabled: Boolean get() = !isLoading
 
-    // Step 2 is Fetch Salt/Nonce/Challenge, enabled if not loading and a key type is selected (always true by default)
-    val isStep2FetchSaltOrNonceChallengeEnabled: Boolean get() = !isLoading
+    // Step 2 is Fetch Nonce/Salt/Challenge, enabled if not loading and a key type is selected (always true by default)
+    val isStep2FetchNonceOrSaltChallengeEnabled: Boolean get() = !isLoading // Renamed
 
     // Step 3 is Generate KeyPair, enabled if not loading, and nonceOrSalt and challenge are present
     val isStep3GenerateKeyPairEnabled: Boolean get() = !isLoading && nonceOrSalt.isNotEmpty() && challenge.isNotEmpty() // Renamed saltOrNonce

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -13,7 +13,8 @@ data class KeyAttestationUiState(
     val sessionId: String? = null,
     val generatedKeyPairData: KeyPairData? = null,
     val progressValue: Float = PlayIntegrityProgressConstants.NO_PROGRESS,
-    val isEcdhAvailable: Boolean = false
+    val isEcdhAvailable: Boolean = false,
+    val serverPublicKey: String = "" // Added for ECDH server public key
 ) {
     val isSaltOrNonceVisible: Boolean get() = saltOrNonce.isNotEmpty()
     val isChallengeVisible: Boolean get() = challenge.isNotEmpty()

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -5,7 +5,7 @@ import dev.keiji.deviceintegrity.ui.main.InfoItem
 import dev.keiji.deviceintegrity.ui.main.playintegrity.PlayIntegrityProgressConstants
 
 data class KeyAttestationUiState(
-    val saltOrNonce: String = "",
+    val nonceOrSalt: String = "", // Renamed from saltOrNonce
     val challenge: String = "",
     val selectedKeyType: CryptoAlgorithm = CryptoAlgorithm.EC, // Default to EC
     val status: String = "", // Keep for general status messages (e.g., "Fetching...", "Failed...")
@@ -16,7 +16,7 @@ data class KeyAttestationUiState(
     val isEcdhAvailable: Boolean = false,
     val serverPublicKey: String = "" // Added for ECDH server public key
 ) {
-    val isSaltOrNonceVisible: Boolean get() = saltOrNonce.isNotEmpty()
+    val isNonceOrSaltVisible: Boolean get() = nonceOrSalt.isNotEmpty() // Renamed from isSaltOrNonceVisible
     val isChallengeVisible: Boolean get() = challenge.isNotEmpty()
 
     val isLoading: Boolean
@@ -28,8 +28,8 @@ data class KeyAttestationUiState(
     // Step 2 is Fetch Salt/Nonce/Challenge, enabled if not loading and a key type is selected (always true by default)
     val isStep2FetchSaltOrNonceChallengeEnabled: Boolean get() = !isLoading
 
-    // Step 3 is Generate KeyPair, enabled if not loading, and saltOrNonce and challenge are present
-    val isStep3GenerateKeyPairEnabled: Boolean get() = !isLoading && saltOrNonce.isNotEmpty() && challenge.isNotEmpty()
+    // Step 3 is Generate KeyPair, enabled if not loading, and nonceOrSalt and challenge are present
+    val isStep3GenerateKeyPairEnabled: Boolean get() = !isLoading && nonceOrSalt.isNotEmpty() && challenge.isNotEmpty() // Renamed saltOrNonce
 
     // Step 4 is Verify Attestation, enabled if not loading and key pair is generated
     val isStep4VerifyAttestationEnabled: Boolean get() = !isLoading && generatedKeyPairData != null

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -77,6 +77,7 @@ class KeyAttestationViewModel @Inject constructor(
                     selectedKeyType = newKeyType,
                     saltOrNonce = "", // Clear salt/nonce
                     challenge = "",   // Clear challenge
+                    serverPublicKey = "", // Clear server public key
                     generatedKeyPairData = null,
                     infoItems = emptyList(),
                     status = "Key algorithm changed to ${newKeyType.label}. Please fetch new Salt/Nonce and Challenge.",
@@ -120,6 +121,7 @@ class KeyAttestationViewModel @Inject constructor(
                     status = statusMessage,
                     saltOrNonce = "", // Clear previous salt/nonce
                     challenge = "",   // Clear previous challenge
+                    serverPublicKey = "", // Clear previous server public key
                     generatedKeyPairData = null, // Clear previous key data
                     infoItems = emptyList(),    // Clear previous results
                     progressValue = PlayIntegrityProgressConstants.FULL_PROGRESS
@@ -161,6 +163,7 @@ class KeyAttestationViewModel @Inject constructor(
                         it.copy(
                             saltOrNonce = response.saltBase64UrlEncoded, // Store SALT for ECDH
                             challenge = response.challengeBase64UrlEncoded,
+                            serverPublicKey = response.publicKeyBase64UrlEncoded, // Store server public key for ECDH
                             status = successMessage,
                             progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
                         )

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -158,6 +158,7 @@ components:
       required:
         - salt
         - challenge
+        - public_key
       properties:
         salt:
           type: string
@@ -169,6 +170,11 @@ components:
           format: byte
           description: Base64URL-encoded challenge.
           example: "Q2hhbGxlbmdlU3RyaW5nSGVyZQ=="
+        public_key:
+          type: string
+          format: byte
+          description: Base64URL-encoded server public key for ECDH.
+          example: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE..."
     VerifySignatureRequestBody:
       type: object
       required:

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -173,8 +173,8 @@ components:
         public_key:
           type: string
           format: byte
-          description: Base64URL-encoded server public key for ECDH (X.509 SubjectPublicKeyInfo, DER).
-          example: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEVs_o5-uQbTjL33K24gSJLIc96-p4pCl-O9mIVVj3LXgY61xXyH3DAJ4lB3L0T0f7vP9p_wI7a8hY0i4jW-Xg"
+          description: Base64URL-encoded server public key for ECDH (X.509 SubjectPublicKeyInfo, DER). The example below is standard Base64 for linter compatibility.
+          example: "dGVzdA==" # Represents "test" in Base64
     VerifySignatureRequestBody:
       type: object
       required:

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -173,8 +173,8 @@ components:
         public_key:
           type: string
           format: byte
-          description: Base64URL-encoded server public key for ECDH.
-          example: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE..."
+          description: Base64URL-encoded server public key for ECDH (X.509 SubjectPublicKeyInfo, DER).
+          example: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEVs_o5-uQbTjL33K24gSJLIc96-p4pCl-O9mIVVj3LXgY61xXyH3DAJ4lB3L0T0f7vP9p_wI7a8hY0i4jW-Xg"
     VerifySignatureRequestBody:
       type: object
       required:


### PR DESCRIPTION
feat: Include ECDH public key in KeyAttestation agreement

Server-side:
- Generates an ECDH P-256 key pair during /prepare/agreement.
- Public key is serialized using X.509 SubjectPublicKeyInfo (DER) format.
- Stores the Base64URL-encoded public key in Datastore.
- Includes the public key in the /prepare/agreement response.
- Updates OpenAPI definition for the new response field.

Android app:
- Updates PrepareAgreementResponse data class for the new public_key field.
- Modifies KeyAttestationViewModel and UiState to store the server's public key.
- Changes button text on KeyAttestationScreen to "Fetch Salt/Challenge/PublicKey" for the ECDH flow.