### PR TITLE
Feat: Add verify/agreement endpoint with dedicated response

 KeyAttestationVerifyApiClient to use VerifyAgreementResponse.

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/KeyAttestationVerifyApiClient.kt
@@ -21,4 +21,9 @@ interface KeyAttestationVerifyApiClient {
     suspend fun prepareAgreement(
         @Body requestBody: PrepareAgreementRequest
     ): PrepareAgreementResponse
+
+    @POST("v1/verify/agreement")
+    suspend fun verifyAgreement(
+        @Body requestBody: VerifyAgreementRequest
+    ): VerifyAgreementResponse
 }

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementRequest.kt
@@ -1,0 +1,24 @@
+package dev.keiji.deviceintegrity.api.keyattestation
+
+import dev.keiji.deviceintegrity.api.DeviceInfo
+import dev.keiji.deviceintegrity.api.SecurityInfo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VerifyAgreementRequest(
+    @SerialName("session_id")
+    val sessionId: String,
+
+    @SerialName("encrypted_data")
+    val encryptedData: String, // Base64URL-encoded, no padding
+
+    @SerialName("client_public_key")
+    val clientPublicKey: String, // Standard Base64-encoded
+
+    @SerialName("device_info")
+    val deviceInfo: DeviceInfo? = null,
+
+    @SerialName("security_info")
+    val securityInfo: SecurityInfo? = null,
+)

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementResponse.kt
@@ -1,0 +1,16 @@
+package dev.keiji.deviceintegrity.api.keyattestation
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VerifyAgreementResponse(
+    @SerialName("session_id")
+    val sessionId: String,
+
+    @SerialName("is_verified")
+    val isVerified: Boolean,
+
+    @SerialName("reason")
+    val reason: String? = null,
+)

--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
@@ -1,11 +1,15 @@
 package dev.keiji.deviceintegrity.repository.contract
 
-import dev.keiji.deviceintegrity.api.keyattestation.PrepareSignatureRequest
-import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
-import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureRequest
-import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureResponse
+// API model imports
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareAgreementRequest
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareAgreementResponse
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
+import dev.keiji.deviceintegrity.api.keyattestation.PrepareSignatureRequest
+import dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementRequest
+import dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementResponse
+import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureRequest
+import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureResponse
+// Local project imports
 import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
 import java.io.IOException
 
@@ -59,6 +63,6 @@ interface KeyAttestationRepository {
      */
     @Throws(ServerException::class, IOException::class)
     suspend fun verifyAgreement(
-        requestBody: dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementRequest // FQDN to avoid import collision if any
-    ): dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementResponse // FQDN for clarity
+        requestBody: VerifyAgreementRequest
+    ): VerifyAgreementResponse
 }

--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/KeyAttestationRepository.kt
@@ -48,4 +48,17 @@ interface KeyAttestationRepository {
     suspend fun prepareAgreement(
         requestBody: PrepareAgreementRequest
     ): PrepareAgreementResponse
+
+    /**
+     * Verifies the key attestation agreement with the server.
+     * @param requestBody The request containing the session ID, encrypted data, client public key, and device/security info.
+     * @return [VerifySignatureResponse] indicating the result of the verification (reuses signature's response type).
+     * @throws ServerException if the server returns an error.
+     * @throws IOException if a network error occurs.
+     * @throws Exception for other unexpected errors.
+     */
+    @Throws(ServerException::class, IOException::class)
+    suspend fun verifyAgreement(
+        requestBody: dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementRequest // FQDN to avoid import collision if any
+    ): dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementResponse // FQDN for clarity
 }

--- a/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyAttestationRepositoryImpl.kt
+++ b/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyAttestationRepositoryImpl.kt
@@ -6,6 +6,7 @@ import dev.keiji.deviceintegrity.api.keyattestation.PrepareAgreementRequest
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareAgreementResponse
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareSignatureRequest
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
+import dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementRequest
 import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureRequest
 import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureResponse
 import dev.keiji.deviceintegrity.repository.contract.KeyAttestationRepository
@@ -80,6 +81,26 @@ class KeyAttestationRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             Log.w(TAG, "PrepareAgreement failed: Unknown error", e)
             throw IOException("An unknown error occurred during prepareAgreement: ${e.message}", e) // Wrap unknown errors
+        }
+    }
+
+    @Throws(ServerException::class, IOException::class)
+    override suspend fun verifyAgreement(
+        requestBody: VerifyAgreementRequest
+    ): VerifyAgreementResponse { // Updated response type
+        try {
+            return apiClient.verifyAgreement(requestBody)
+        } catch (e: HttpException) {
+            val errorBody = e.response()?.errorBody()?.string()
+            val errorMessage = parseErrorMessage(errorBody)
+            Log.w(TAG, "VerifyAgreement failed: HTTP ${e.code()}, Body: $errorBody", e)
+            throw ServerException(errorCode = e.code(), errorMessage = errorMessage, cause = e)
+        } catch (e: IOException) {
+            Log.w(TAG, "VerifyAgreement failed: Network error", e)
+            throw e // Re-throw IOException directly
+        } catch (e: Exception) {
+            Log.w(TAG, "VerifyAgreement failed: Unknown error", e)
+            throw IOException("An unknown error occurred during verifyAgreement: ${e.message}", e) // Wrap unknown errors
         }
     }
 

--- a/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyAttestationRepositoryImpl.kt
+++ b/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/KeyAttestationRepositoryImpl.kt
@@ -7,6 +7,7 @@ import dev.keiji.deviceintegrity.api.keyattestation.PrepareAgreementResponse
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareSignatureRequest
 import dev.keiji.deviceintegrity.api.keyattestation.PrepareResponse
 import dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementRequest
+import dev.keiji.deviceintegrity.api.keyattestation.VerifyAgreementResponse // Added missing import
 import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureRequest
 import dev.keiji.deviceintegrity.api.keyattestation.VerifySignatureResponse
 import dev.keiji.deviceintegrity.repository.contract.KeyAttestationRepository

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -243,7 +243,7 @@ components:
           type: string
           format: byte # Base64URL encoded, no padding
           description: Base64URL-encoded (no padding) encrypted data.
-          example: "dGVzdA" # "test"
+          example: "SGVsbG8gV29ybGQ=" # "Hello World"
         client_public_key:
           type: string
           format: base64 # Standard Base64 encoded

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -77,12 +77,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal Server Error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+    # Removed the duplicate '500' entry from here
 
   /v1/verify/signature:
     post:
@@ -248,7 +243,7 @@ components:
           type: string
           format: byte # Base64URL encoded, no padding
           description: Base64URL-encoded (no padding) encrypted data.
-          example: "dGVzdF9lbmNvZGluZw" # "test_encoding"
+          example: "dGVzdA" # "test"
         client_public_key:
           type: string
           format: base64 # Standard Base64 encoded

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -64,7 +64,7 @@ paths:
           content:
             application/json:
               schema:
-              $ref: '#/components/schemas/VerifyAgreementResponseBody'
+                $ref: '#/components/schemas/VerifyAgreementResponseBody' # Corrected: $ref is a child of schema
         '400':
           description: Bad Request (e.g., missing parameters).
           content:
@@ -110,12 +110,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal Server Error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+    # Removed duplicate '500' entry
 
   /v1/prepare/agreement:
     post:
@@ -253,7 +248,7 @@ components:
           type: string
           format: byte # Base64URL encoded, no padding
           description: Base64URL-encoded (no padding) encrypted data.
-          example: "ZW5jcnlwdGVkX2RhdGE"
+          example: "dGVzdF9lbmNvZGluZw" # "test_encoding"
         client_public_key:
           type: string
           format: base64 # Standard Base64 encoded

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -44,6 +44,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /v1/verify/agreement:
+    post:
+      summary: Verify Key Attestation Agreement
+      description: Verifies the Key Attestation Agreement (mock implementation).
+      operationId: verifyAgreementKeyAttestation
+      tags:
+        - KeyAttestationV1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyAgreementRequestBody'
+      responses:
+        '200':
+          description: Successfully processed agreement verification (mock response).
+          content:
+            application/json:
+              schema:
+              $ref: '#/components/schemas/VerifyAgreementResponseBody'
+        '400':
+          description: Bad Request (e.g., missing parameters).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal Server Error.
           content:
@@ -204,6 +237,50 @@ components:
             format: base64
           description: Array of standard Base64-encoded certificate strings.
           example: ["Y2VydDE=", "Y2VydDI="]
+    VerifyAgreementRequestBody: # New Request Body for verify/agreement
+      type: object
+      required:
+        - session_id
+        - encrypted_data
+        - client_public_key
+        # device_info and security_info are optional but recommended
+      properties:
+        session_id:
+          type: string
+          description: Client session ID.
+          example: "session-abcde-67890"
+        encrypted_data:
+          type: string
+          format: byte # Base64URL encoded, no padding
+          description: Base64URL-encoded (no padding) encrypted data.
+          example: "ZW5jcnlwdGVkX2RhdGE"
+        client_public_key:
+          type: string
+          format: base64 # Standard Base64 encoded
+          description: Standard Base64-encoded client's public key (X.509 SubjectPublicKeyInfo, DER).
+          example: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEE5g3G..." # Example of a Base64 encoded key
+        device_info:
+          $ref: '#/components/schemas/DeviceInfo'
+        security_info:
+          $ref: '#/components/schemas/SecurityInfo'
+    VerifyAgreementResponseBody: # New Response Body for verify/agreement
+      type: object
+      required:
+        - session_id
+        - is_verified
+      properties:
+        session_id:
+          type: string
+          description: Client session ID.
+          example: "session-abcde-67890"
+        is_verified:
+          type: boolean
+          description: Result of the agreement verification.
+          example: true
+        reason:
+          type: string
+          description: Reason for verification status (optional).
+          example: "Key agreement verified successfully (mock)."
     VerifySignatureResponseBody:
       type: object
       required:


### PR DESCRIPTION
Feat: Add verify/agreement endpoint with dedicated response

Server-side:
- Added VerifyAgreementResponseBody schema to OpenAPI.
- Updated /v1/verify/agreement endpoint to use VerifyAgreementResponseBody.
- Modified mock verify_agreement_attestation function to return the new response structure.

Android client-side:
- Created VerifyAgreementResponse data class.
- Updated KeyAttestationVerifyApiClient to use VerifyAgreementResponse.
- Updated KeyAttestationRepository (contract and impl) to use VerifyAgreementResponse.
- Refactored KeyAttestationRepository to use imports instead of FQCNs.