### PR TITLE
Okay, here's how I'll approach adding HKDF key derivation using stand…

### DIFF
--- a/android/crypto/contract/src/main/java/com/example/crypto/contract/SharedKeyDerivator.kt
+++ b/android/crypto/contract/src/main/java/com/example/crypto/contract/SharedKeyDerivator.kt
@@ -1,0 +1,19 @@
+package com.example.crypto.contract
+
+import java.security.PrivateKey
+import java.security.PublicKey
+
+/**
+ * Interface for deriving a shared key from a key pair.
+ */
+interface SharedKeyDerivator {
+    /**
+     * Derives a shared key using the provided public key, private key, and optional salt.
+     *
+     * @param publicKey The public key.
+     * @param privateKey The private key.
+     * @param salt An optional salt for the key derivation.
+     * @return The derived shared key as a ByteArray.
+     */
+    fun deriveKey(publicKey: PublicKey, privateKey: PrivateKey, salt: ByteArray? = null): ByteArray
+}

--- a/android/crypto/impl/src/main/java/com/example/crypto/impl/HkdfKeyDerivator.kt
+++ b/android/crypto/impl/src/main/java/com/example/crypto/impl/HkdfKeyDerivator.kt
@@ -1,0 +1,94 @@
+package com.example.crypto.impl
+
+import com.example.crypto.contract.SharedKeyDerivator
+import java.security.InvalidKeyException
+import java.security.NoSuchAlgorithmException
+import java.security.PrivateKey
+import java.security.PublicKey
+import javax.crypto.KeyAgreement
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import javax.inject.Inject
+
+/**
+ * Implements SharedKeyDerivator using HKDF (HMAC-based Key Derivation Function)
+ * with standard Android APIs.
+ */
+class HkdfKeyDerivator @Inject constructor() : SharedKeyDerivator {
+
+    companion object {
+        private const val KEY_AGREEMENT_ALGORITHM = "ECDH"
+        private const val HMAC_ALGORITHM = "HmacSHA256"
+        private const val DERIVED_KEY_SIZE_BYTES = 32 // 256 bits
+        private const val HASH_LENGTH_BYTES = 32 // SHA-256 output length
+    }
+
+    override fun deriveKey(publicKey: PublicKey, privateKey: PrivateKey, salt: ByteArray?): ByteArray {
+        // 1. Perform Key Agreement (ECDH)
+        val sharedSecret = performKeyAgreement(publicKey, privateKey)
+
+        // 2. Perform HKDF (RFC 5869)
+        return hkdf(sharedSecret, salt, null, DERIVED_KEY_SIZE_BYTES)
+    }
+
+    private fun performKeyAgreement(publicKey: PublicKey, privateKey: PrivateKey): ByteArray {
+        try {
+            val keyAgreement = KeyAgreement.getInstance(KEY_AGREEMENT_ALGORITHM)
+            keyAgreement.init(privateKey)
+            keyAgreement.doPhase(publicKey, true)
+            return keyAgreement.generateSecret()
+        } catch (e: NoSuchAlgorithmException) {
+            throw IllegalStateException("ECDH algorithm not found", e)
+        } catch (e: InvalidKeyException) {
+            throw IllegalArgumentException("Invalid key for ECDH", e)
+        }
+    }
+
+    /**
+     * HKDF (HMAC-based Key Derivation Function) - RFC 5869.
+     *
+     * @param ikm Input Keying Material.
+     * @param salt Optional salt value (a non-secret random value). If not provided, it is set to a byte array of HASH_LENGTH_BYTES zeros.
+     * @param info Optional context and application specific information.
+     * @param length Desired output key length in bytes. Max length is 255 * HASH_LENGTH_BYTES.
+     * @return Output Keying Material (OKM) of 'length' bytes.
+     */
+    private fun hkdf(ikm: ByteArray, salt: ByteArray?, info: ByteArray?, length: Int): ByteArray {
+        // --- HKDF-Extract ---
+        val actualSalt = salt ?: ByteArray(HASH_LENGTH_BYTES) // If salt is not provided, use a string of HashLen zeros.
+        val prk = hmac(actualSalt, ikm) // PseudoRandom Key
+
+        // --- HKDF-Expand ---
+        if (length < 0) throw IllegalArgumentException("Requested key length must be non-negative.")
+        if (length > 255 * HASH_LENGTH_BYTES) {
+            throw IllegalArgumentException("Requested key length $length is too long for $HMAC_ALGORITHM.")
+        }
+
+        val okm = ByteArray(length) // Output Keying Material
+        var t = ByteArray(0)
+        var n = 0 // Iteration counter
+
+        while (t.size < length) {
+            n++
+            if (n > 255) { // Should be caught by the length check above, but good for safety.
+                throw IllegalStateException("HKDF expansion iteration limit reached.")
+            }
+            val hmacInput = t + (info ?: ByteArray(0)) + byteArrayOf(n.toByte())
+            t = hmac(prk, hmacInput)
+            System.arraycopy(t, 0, okm, (n - 1) * HASH_LENGTH_BYTES, minOf(t.size, length - (n - 1) * HASH_LENGTH_BYTES))
+        }
+        return okm
+    }
+
+    private fun hmac(key: ByteArray, data: ByteArray): ByteArray {
+        try {
+            val mac = Mac.getInstance(HMAC_ALGORITHM)
+            mac.init(SecretKeySpec(key, HMAC_ALGORITHM))
+            return mac.doFinal(data)
+        } catch (e: NoSuchAlgorithmException) {
+            throw IllegalStateException("$HMAC_ALGORITHM not found", e)
+        } catch (e: InvalidKeyException) {
+            throw IllegalArgumentException("Invalid key for HMAC", e)
+        }
+    }
+}

--- a/android/crypto/impl/src/test/java/com/example/crypto/impl/HkdfKeyDerivatorTest.kt
+++ b/android/crypto/impl/src/test/java/com/example/crypto/impl/HkdfKeyDerivatorTest.kt
@@ -1,0 +1,133 @@
+package com.example.crypto.impl
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.SecureRandom
+import java.security.spec.ECGenParameterSpec
+
+class HkdfKeyDerivatorTest {
+
+    private lateinit var derivator: HkdfKeyDerivator
+
+    // Using NIST P-256 curve for ECDH
+    private val ecSpec = ECGenParameterSpec("secp256r1")
+
+    @Before
+    fun setUp() {
+        // Security.addProvider(org.bouncycastle.jce.provider.BouncyCastleProvider()) // Not needed
+        derivator = HkdfKeyDerivator()
+    }
+
+    private fun generateEcKeyPair(): KeyPair {
+        val g = KeyPairGenerator.getInstance("EC") // Use default provider
+        g.initialize(ecSpec, SecureRandom())
+        return g.generateKeyPair()
+    }
+
+    @Test
+    fun `deriveKey returns a key of correct length`() {
+        val keyPair1 = generateEcKeyPair()
+        val keyPair2 = generateEcKeyPair()
+
+        val derivedKey = derivator.deriveKey(keyPair2.public, keyPair1.private)
+        assertNotNull(derivedKey)
+        assertEquals(32, derivedKey.size) // Expecting 256-bit key
+    }
+
+    @Test
+    fun `deriveKey is consistent for same inputs`() {
+        val keyPair1 = generateEcKeyPair()
+        val keyPair2 = generateEcKeyPair()
+
+        val derivedKey1 = derivator.deriveKey(keyPair2.public, keyPair1.private)
+        val derivedKey2 = derivator.deriveKey(keyPair2.public, keyPair1.private)
+
+        assertArrayEquals(derivedKey1, derivedKey2)
+    }
+
+    @Test
+    fun `deriveKey produces different keys for different key pairs`() {
+        val keyPair1 = generateEcKeyPair()
+        val keyPair2 = generateEcKeyPair()
+        val keyPair3 = generateEcKeyPair() // A different party
+
+        // Key derived between party 1 and party 2
+        val derivedKey12 = derivator.deriveKey(keyPair2.public, keyPair1.private)
+
+        // Key derived between party 1 and party 3
+        val derivedKey13 = derivator.deriveKey(keyPair3.public, keyPair1.private)
+
+        assertNotEquals(derivedKey12.contentToString(), derivedKey13.contentToString())
+    }
+
+    @Test
+    fun `deriveKey with same salt produces same key`() {
+        val keyPair1 = generateEcKeyPair()
+        val keyPair2 = generateEcKeyPair()
+        val salt = "test_salt".toByteArray()
+
+        val derivedKey1 = derivator.deriveKey(keyPair2.public, keyPair1.private, salt)
+        val derivedKey2 = derivator.deriveKey(keyPair2.public, keyPair1.private, salt)
+
+        assertArrayEquals(derivedKey1, derivedKey2)
+    }
+
+    @Test
+    fun `deriveKey with different salts produces different keys`() {
+        val keyPair1 = generateEcKeyPair()
+        val keyPair2 = generateEcKeyPair()
+        val salt1 = "salt1".toByteArray()
+        val salt2 = "salt2".toByteArray()
+
+        val derivedKey1 = derivator.deriveKey(keyPair2.public, keyPair1.private, salt1)
+        val derivedKey2 = derivator.deriveKey(keyPair2.public, keyPair1.private, salt2)
+
+        assertNotEquals(derivedKey1.contentToString(), derivedKey2.contentToString())
+    }
+
+    @Test
+    fun `deriveKey with and without salt produces different keys`() {
+        val keyPair1 = generateEcKeyPair()
+        val keyPair2 = generateEcKeyPair()
+        val salt = "test_salt".toByteArray()
+
+        val derivedKeyWithSalt = derivator.deriveKey(keyPair2.public, keyPair1.private, salt)
+        val derivedKeyWithoutSalt = derivator.deriveKey(keyPair2.public, keyPair1.private, null)
+
+        assertNotEquals(derivedKeyWithSalt.contentToString(), derivedKeyWithoutSalt.contentToString())
+    }
+
+    @Test
+    fun `deriveKey works for both sides of key exchange (ECDH property)`() {
+        val keyPairA = generateEcKeyPair() // Alice's key pair
+        val keyPairB = generateEcKeyPair() // Bob's key pair
+
+        // Alice computes shared key using Bob's public key and her private key
+        val derivedKeyAlice = derivator.deriveKey(keyPairB.public, keyPairA.private)
+
+        // Bob computes shared key using Alice's public key and his private key
+        val derivedKeyBob = derivator.deriveKey(keyPairA.public, keyPairB.private)
+
+        assertArrayEquals(derivedKeyAlice, derivedKeyBob)
+    }
+
+    @Test
+    fun `deriveKey with salt works for both sides of key exchange`() {
+        val keyPairA = generateEcKeyPair()
+        val keyPairB = generateEcKeyPair()
+        val salt = "common_salt".toByteArray()
+
+        val derivedKeyAlice = derivator.deriveKey(keyPairB.public, keyPairA.private, salt)
+        val derivedKeyBob = derivator.deriveKey(keyPairA.public, keyPairB.private, salt)
+
+        assertArrayEquals(derivedKeyAlice, derivedKeyBob)
+    }
+}


### PR DESCRIPTION
…ard Android APIs:

First, I'll define a `SharedKeyDerivator` interface within the `crypto:contract` module.

Next, I'll implement `HkdfKeyDerivator` in the `crypto:impl` module. This implementation will utilize ECDH for key agreement and a manual HKDF (as specified in RFC 5869) for the key derivation process.

Then, I'll write unit tests to ensure the `HkdfKeyDerivator` functions correctly.

Finally, I'll remove the unused BouncyCastle dependency and any associated code to keep things clean.