### PR TITLE
feat: Update verify/agreement response with device, security, and attestation info

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementResponse.kt
@@ -1,5 +1,7 @@
 package dev.keiji.deviceintegrity.api.keyattestation
 
+import dev.keiji.deviceintegrity.api.DeviceInfo
+import dev.keiji.deviceintegrity.api.SecurityInfo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,14 +14,14 @@ data class VerifyAgreementResponse(
     val isVerified: Boolean,
 
     @SerialName("reason")
-    val reason: String? = null,
+    val reason: String? = null, // reason can still be optional
 
     @SerialName("attestation_info")
-    val attestationInfo: AttestationInfo? = null,
+    val attestationInfo: AttestationInfo,
 
     @SerialName("device_info")
-    val deviceInfo: dev.keiji.deviceintegrity.api.DeviceInfo? = null,
+    val deviceInfo: DeviceInfo,
 
     @SerialName("security_info")
-    val securityInfo: dev.keiji.deviceintegrity.api.SecurityInfo? = null,
+    val securityInfo: SecurityInfo,
 )

--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementResponse.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementResponse.kt
@@ -13,4 +13,13 @@ data class VerifyAgreementResponse(
 
     @SerialName("reason")
     val reason: String? = null,
+
+    @SerialName("attestation_info")
+    val attestationInfo: AttestationInfo? = null,
+
+    @SerialName("device_info")
+    val deviceInfo: dev.keiji.deviceintegrity.api.DeviceInfo? = null,
+
+    @SerialName("security_info")
+    val securityInfo: dev.keiji.deviceintegrity.api.SecurityInfo? = null,
 )

--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -1230,34 +1230,56 @@ def verify_agreement_attestation():
             )
             return jsonify({"error": "Agreement Session ID not found, expired, or invalid."}), 403
 
-        # For the new VerifyAgreementResponseBody, we only need session_id, is_verified, and reason.
+        # Mocked AttestationInfo structure
+        mock_attestation_info = {
+            "attestation_version": 0, # Mock value
+            "attestation_security_level": 0, # Mock value (e.g., TEE)
+            "keymint_version": 0, # Mock value
+            "keymint_security_level": 0, # Mock value
+            "attestation_challenge": base64url_encode(b"mock_agreement_challenge"), # Mock challenge
+            "software_enforced_properties": {}, # Empty for mock agreement
+            "hardware_enforced_properties": {}  # Empty for mock agreement
+        }
+
+        # Use device_info and security_info from request, or provide defaults
+        final_device_info = device_info_from_request if device_info_from_request else {
+            "brand": "MockBrand", "model": "MockModel", "device": "MockDevice", "product": "MockProduct",
+            "manufacturer": "MockManufacturer", "hardware": "MockHardware", "board": "MockBoard",
+            "bootloader": "MockBootloader", "version_release": "0", "sdk_int": 0,
+            "fingerprint": "MockFingerprint", "security_patch": "1970-01-01"
+        }
+        final_security_info = security_info_from_request if security_info_from_request else {
+            "is_device_lock_enabled": False, "is_biometrics_enabled": False,
+            "has_class_3_authenticator": False, "has_strongbox": False
+        }
+
         final_response = {
             "session_id": session_id,
             "is_verified": True, # Mock success
-            "reason": "Key agreement verified successfully (mock)."
-            # No attestation_info, device_info, or security_info for this specific response
+            "reason": "Key agreement verified successfully (mock).",
+            "attestation_info": mock_attestation_info,
+            "device_info": final_device_info,
+            "security_info": final_security_info
         }
 
-        # Storing result in Datastore can still include more details if useful for internal logging,
-        # but the client response is simpler.
-        # For simplicity, we'll just store the reason for the mock.
-        # The payload_data_json_str already contains device/security info if provided by client.
-        # The attestation_data part can be minimal or reflect what was "verified" in the mock.
-        mock_internal_verification_details = {
+        # Storing result in Datastore
+        # The attestation_data part can include the mocked attestation_info for consistency
+        attestation_data_for_datastore = {
+            "attestation_info": mock_attestation_info,
             "verification_type": "agreement_mock",
             "client_public_key_provided": bool(client_public_key_b64),
             "encrypted_data_provided": bool(encrypted_data_b64url)
         }
-        attestation_data_json_str_success = json.dumps(mock_internal_verification_details)
+        attestation_data_json_str_success = json.dumps(attestation_data_for_datastore)
 
         store_key_attestation_result(
             session_id,
-            "verified_agreement_mock", # Result type
-            final_response["reason"],    # Reason
-            payload_data_json_str,       # Original payload data (device_info, etc.)
-            attestation_data_json_str_success # Internal mock verification details
+            "verified_agreement_mock",
+            final_response["reason"],
+            payload_data_json_str, # Contains original device_info, security_info from request
+            attestation_data_json_str_success
         )
-        delete_agreement_key_attestation_session(session_id) # Clean up session after mock verification
+        delete_agreement_key_attestation_session(session_id)
 
         logger.info(f"Successfully verified Key Attestation Agreement (mock) for session_id: {session_id}")
         return jsonify(final_response), 200
@@ -1265,14 +1287,18 @@ def verify_agreement_attestation():
     except ValueError as e:
         current_session_id = locals().get("session_id", "unknown_session_agreement_value_error")
         payload_str = locals().get("payload_data_json_str", "{}")
+        # Include empty attestation_info in error case if schema expects it
+        att_props_str = json.dumps({"attestation_info": {}})
         logger.warning(f"ValueError in /verify/agreement for session {current_session_id}: {e}")
-        store_key_attestation_result(current_session_id, "failed", str(e), payload_str, "{}")
+        store_key_attestation_result(current_session_id, "failed", str(e), payload_str, att_props_str)
         return jsonify({"error": str(e)}), 400
     except Exception as e:
         current_session_id = locals().get("session_id", "unknown_session_agreement_exception")
         payload_str = locals().get("payload_data_json_str", "{}")
+        # Include empty attestation_info in error case if schema expects it
+        att_props_str = json.dumps({"attestation_info": {}})
         logger.error(f"Error in /verify/agreement endpoint for session {current_session_id}: {e}", exc_info=True)
-        store_key_attestation_result(current_session_id, "failed", "An unexpected error occurred during agreement verification.", payload_str, "{}")
+        store_key_attestation_result(current_session_id, "failed", "An unexpected error occurred during agreement verification.", payload_str, att_props_str)
         return jsonify({"error": "An unexpected error occurred"}), 500
 
 if __name__ == '__main__':

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -258,7 +258,9 @@ components:
       required:
         - session_id
         - is_verified
-        # attestation_info, device_info, and security_info are optional
+        - attestation_info
+        - device_info
+        - security_info
       properties:
         session_id:
           type: string
@@ -270,14 +272,14 @@ components:
           example: true
         reason:
           type: string
-          description: Reason for verification status (optional).
+          description: Reason for verification status (optional). # Reason can still be optional
           example: "Key agreement verified successfully (mock)."
         attestation_info:
-          $ref: '#/components/schemas/AttestationInfo'
+          $ref: '#/components/schemas/AttestationInfo' # No nullable: true here
         device_info:
-          $ref: '#/components/schemas/DeviceInfo'
+          $ref: '#/components/schemas/DeviceInfo'   # No nullable: true here
         security_info:
-          $ref: '#/components/schemas/SecurityInfo'
+          $ref: '#/components/schemas/SecurityInfo' # No nullable: true here
     VerifySignatureResponseBody:
       type: object
       required:

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -258,6 +258,7 @@ components:
       required:
         - session_id
         - is_verified
+        # attestation_info, device_info, and security_info are optional
       properties:
         session_id:
           type: string
@@ -271,6 +272,15 @@ components:
           type: string
           description: Reason for verification status (optional).
           example: "Key agreement verified successfully (mock)."
+        attestation_info:
+          $ref: '#/components/schemas/AttestationInfo'
+          nullable: true # Explicitly marking as nullable
+        device_info:
+          $ref: '#/components/schemas/DeviceInfo'
+          nullable: true # Explicitly marking as nullable
+        security_info:
+          $ref: '#/components/schemas/SecurityInfo'
+          nullable: true # Explicitly marking as nullable
     VerifySignatureResponseBody:
       type: object
       required:

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -274,13 +274,10 @@ components:
           example: "Key agreement verified successfully (mock)."
         attestation_info:
           $ref: '#/components/schemas/AttestationInfo'
-          nullable: true # Explicitly marking as nullable
         device_info:
           $ref: '#/components/schemas/DeviceInfo'
-          nullable: true # Explicitly marking as nullable
         security_info:
           $ref: '#/components/schemas/SecurityInfo'
-          nullable: true # Explicitly marking as nullable
     VerifySignatureResponseBody:
       type: object
       required:


### PR DESCRIPTION
- Modifies the server-side mock implementation of /v1/verify/agreement to include device_info, security_info, and a mocked attestation_info in the JSON response.
- Updates the OpenAPI definition for VerifyAgreementResponseBody to reflect these new optional fields.
- Adjusts the Android Retrofit data class VerifyAgreementResponse.kt to include the new nullable fields.