### PR TITLE
Fix: Correct package structure for Gunicorn in Key Attestation service

### DIFF
--- a/server/key_attestation/Dockerfile
+++ b/server/key_attestation/Dockerfile
@@ -10,8 +10,8 @@ COPY requirements.txt .
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the current directory contents into the container at /app
-COPY . .
+# Copy the current directory contents into the container at /app/key_attestation_pkg/
+COPY . /app/key_attestation_pkg/
 
 # Make port $PORT available to the world outside this container
 # Cloud Run sets this environment variable.
@@ -21,4 +21,4 @@ EXPOSE $PORT
 ENV PORT 8080
 
 # Run app.py when the container launches
-CMD exec gunicorn -b :$PORT key_attestation:app
+CMD exec gunicorn -b :$PORT key_attestation_pkg.key_attestation:app


### PR DESCRIPTION
Resolves ImportError for relative imports by:
- Copying application files into a subdirectory `key_attestation_pkg` within the Docker image.
- Updating the Gunicorn CMD to load the application as `key_attestation_pkg.key_attestation:app`.

This ensures that `key_attestation.py` is treated as part of a package, allowing its relative imports to resolve correctly when run by Gunicorn.