### PR TITLE
Refactor Play Integrity UI to display Device Integrity details

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/InfoItemContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/InfoItemContent.kt
@@ -26,12 +26,14 @@ import androidx.compose.ui.res.painterResource // Added
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.keiji.deviceintegrity.ui.main.R // Import for R.drawable
+import dev.keiji.deviceintegrity.ui.main.playintegrity.DeviceIntegrityResults
 
 @Composable
 fun InfoItemContent(
     status: String,
     isVerifiedSuccessfully: Boolean,
     infoItems: List<InfoItem>,
+    deviceRecognitionVerdict: List<String> = emptyList(), // Added parameter
     onCopyClick: () -> Unit,
     onShareClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -47,6 +49,11 @@ fun InfoItemContent(
             },
             style = MaterialTheme.typography.titleMedium
         )
+
+        // Display DeviceIntegrityResults if the verdict is not empty
+        if (deviceRecognitionVerdict.isNotEmpty()) {
+            DeviceIntegrityResults(deviceRecognitionVerdict = deviceRecognitionVerdict)
+        }
 
         if (infoItems.isNotEmpty()) {
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityContent.kt
@@ -128,6 +128,7 @@ fun ClassicPlayIntegrityContent(
             status = statusToDisplay,
             isVerifiedSuccessfully = uiState.resultInfoItems.isNotEmpty() && uiState.errorMessages.isEmpty() && statusToDisplay.contains("complete", ignoreCase = true) && !statusToDisplay.contains("Failed", ignoreCase = true),
             infoItems = uiState.resultInfoItems,
+            deviceRecognitionVerdict = uiState.serverVerificationPayload?.deviceIntegrity?.deviceRecognitionVerdict ?: emptyList(),
             onCopyClick = {
                 val textToCopy = InfoItemFormatter.formatInfoItems(uiState.resultInfoItems)
                 clipboardManager.setText(AnnotatedString(textToCopy))

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/DeviceIntegrityResults.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/DeviceIntegrityResults.kt
@@ -1,0 +1,56 @@
+package dev.keiji.deviceintegrity.ui.main.playintegrity
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.keiji.deviceintegrity.R
+
+@Composable
+fun DeviceIntegrityResults(
+    deviceRecognitionVerdict: List<String>
+) {
+    val integrityLevels = listOf(
+        "MEETS_STRONG_INTEGRITY",
+        "MEETS_DEVICE_INTEGRITY",
+        "MEETS_BASIC_INTEGRITY"
+    )
+
+    Column(modifier = Modifier.padding(vertical = 8.dp)) {
+        Text(
+            text = "Device Integrity",
+            fontSize = 18.sp, // Slightly larger font size
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+
+        integrityLevels.forEach { level ->
+            val hasLevel = deviceRecognitionVerdict.contains(level)
+            val iconRes = if (hasLevel) R.drawable.ic_shield_fill else R.drawable.ic_gpp_bad
+            val text = level.replace("_", " ").lowercase().replaceFirstChar { it.uppercase() }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    painter = painterResource(id = iconRes),
+                    contentDescription = text,
+                    modifier = Modifier.size(28.dp) // Slightly larger icon size
+                )
+                Text(
+                    text = text,
+                    fontSize = 16.sp, // Slightly larger font size
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+    }
+}

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityContent.kt
@@ -130,6 +130,7 @@ fun StandardPlayIntegrityContent(
             status = statusToDisplay,
             isVerifiedSuccessfully = uiState.resultInfoItems.isNotEmpty() && uiState.errorMessages.isEmpty() && statusToDisplay.contains("complete", ignoreCase = true) && !statusToDisplay.contains("Failed", ignoreCase = true),
             infoItems = uiState.resultInfoItems,
+            deviceRecognitionVerdict = uiState.serverVerificationPayload?.deviceIntegrity?.deviceRecognitionVerdict ?: emptyList(),
             onCopyClick = {
                 val textToCopy = InfoItemFormatter.formatInfoItems(uiState.resultInfoItems)
                 clipboardManager.setText(AnnotatedString(textToCopy))

--- a/android/ui/main/src/main/res/drawable/ic_gpp_bad.xml
+++ b/android/ui/main/src/main/res/drawable/ic_gpp_bad.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#9F9F9F">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,2L4,5v6.09c0,5.05 3.41,9.76 8,10.91c4.59,-1.15 8,-5.86 8,-10.91V5L12,2zM10.29,14.71L8.17,12.59c-0.39,-0.39 -0.39,-1.02 0,-1.41c0.39,-0.39 1.02,-0.39 1.41,0L11,12.17l1.41,-1.41c0.39,-0.39 1.02,-0.39 1.41,0c0.39,0.39 0.39,1.02 0,1.41L12.41,13.5l1.42,1.42c0.39,0.39 0.39,1.02 0,1.41c-0.39,0.39 -1.02,0.39 -1.41,0L11,14.91l-1.42,1.42c-0.39,0.39 -1.02,0.39 -1.41,0c-0.39,-0.39 -0.39,-1.02 0,-1.41L10.29,14.71z"/>
+</vector>

--- a/android/ui/main/src/main/res/drawable/ic_shield_fill.xml
+++ b/android/ui/main/src/main/res/drawable/ic_shield_fill.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#3DDC84">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5L12,1z"/>
+</vector>


### PR DESCRIPTION
This commit introduces the following changes:

- Added SVG icons for Shield (Fill) and Gpp Bad.
- Created a new Composable `DeviceIntegrityResults` to display device integrity information (MEETS_STRONG_INTEGRITY, MEETS_DEVICE_INTEGRITY, MEETS_BASIC_INTEGRITY) with appropriate icons and styling.
- Modified `InfoItemContent` to include `DeviceIntegrityResults` between the status and the detailed information list.
- Updated `ClassicPlayIntegrityContent` and `StandardPlayIntegrityContent` to extract `deviceRecognitionVerdict` from the `serverVerificationPayload` in their respective UiStates and pass it to `InfoItemContent`.

These changes allow you to see a clear summary of the device integrity check results within the Play Integrity screens.