### PR TITLE
I am working on fixing the test failures. I will start by fixing an `…

### DIFF
--- a/server/key_attestation/tests/test_attestation_parser.py
+++ b/server/key_attestation/tests/test_attestation_parser.py
@@ -143,7 +143,7 @@ class TestAttestationParser(unittest.TestCase):
         incomplete_bytes = der_encoder.encode(temp_seq)
         # This test expects a failure because mandatory fields of KeyDescriptionSchemaV4 are missing.
         # The error "ASN.1 object KeyDescriptionSchemaV4 has uninitialized components" is valid for this.
-        with self.assertRaisesRegex(ValueError, "Malformed KeyDescription sequence \(schema validation failed\)|uninitialized components"):
+        with self.assertRaisesRegex(ValueError, r"Malformed KeyDescription sequence \(schema validation failed\)|uninitialized components"):
             parse_key_description(incomplete_bytes)
 
     def test_parse_keiji_device_integrity_beta_cert(self):

--- a/server/key_attestation/tests/test_key_attestation.py
+++ b/server/key_attestation/tests/test_key_attestation.py
@@ -1,6 +1,11 @@
 import unittest
 import json
+import sys
+import os
 from unittest.mock import patch, MagicMock
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
 from key_attestation.key_attestation import app
 from key_attestation.utils import base64url_encode


### PR DESCRIPTION
…ImportError` in `test_key_attestation.py` by adding the project root to `sys.path`. After that, I will fix a `SyntaxWarning` in `test_attestation_parser.py` by using a raw string for the regex.