### PR TITLE
feat: Adjust key-attestation agreement verification

### DIFF
--- a/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementRequest.kt
+++ b/android/api/src/main/java/dev/keiji/deviceintegrity/api/keyattestation/VerifyAgreementRequest.kt
@@ -11,17 +11,17 @@ data class VerifyAgreementRequest(
     val sessionId: String,
 
     @SerialName("encrypted_data")
-    val encryptedData: String, // Base64URL-encoded, no padding
-
-    @SerialName("client_public_key")
-    val clientPublicKey: String, // Standard Base64-encoded
+    val encryptedDataBase64UrlEncoded: String,
 
     @SerialName("salt")
-    val salt: String, // Base64URL-encoded, no padding
+    val saltBase64UrlEncoded: String,
+
+    @SerialName("certificate_chain")
+    val certificateChainBase64Encoded: List<String>,
 
     @SerialName("device_info")
-    val deviceInfo: DeviceInfo? = null,
+    val deviceInfo: DeviceInfo,
 
     @SerialName("security_info")
-    val securityInfo: SecurityInfo? = null,
+    val securityInfo: SecurityInfo,
 )

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -386,14 +386,17 @@ class KeyAttestationViewModel @Inject constructor(
                     val sessionIdBytes = currentSessionId.toByteArray(Charsets.US_ASCII)
                     val encryptedData = encrypt.encrypt(serverNonceBytes, derivedSecretKey, sessionIdBytes)
                     val encryptedDataBase64Url = Base64Utils.UrlSafeNoPadding.encode(encryptedData)
-                    val clientPublicKeyB64Url = Base64Utils.UrlSafeNoPadding.encode(keyPair.public.encoded)
                     val clientSaltB64Url = Base64Utils.UrlSafeNoPadding.encode(clientSaltBytes)
+                    val certificateChainBase64Encoded =
+                        currentKeyPairData.certificates.map { cert ->
+                            Base64.Default.encode(cert.encoded)
+                        }
 
                     val request = VerifyAgreementRequest(
                         sessionId = currentSessionId,
-                        encryptedData = encryptedDataBase64Url,
-                        clientPublicKey = clientPublicKeyB64Url,
-                        salt = clientSaltB64Url,
+                        encryptedDataBase64UrlEncoded = encryptedDataBase64Url,
+                        saltBase64UrlEncoded = clientSaltB64Url,
+                        certificateChainBase64Encoded = certificateChainBase64Encoded,
                         deviceInfo = DeviceInfo(
                             brand = deviceInfoProvider.BRAND,
                             model = deviceInfoProvider.MODEL,

--- a/server/key_attestation/cryptographic_utils.py
+++ b/server/key_attestation/cryptographic_utils.py
@@ -10,6 +10,10 @@ from cryptography.hazmat.backends import default_backend
 
 logger = logging.getLogger(__name__)
 
+def base64url_encode(data_bytes: bytes) -> str:
+    """Encodes bytes to a Base64URL string (RFC 4648 Section 5)."""
+    return base64.urlsafe_b64encode(data_bytes).decode('utf-8').rstrip('=')
+
 def base64url_decode(base64url_string):
     """Decodes a Base64URL string to bytes."""
     padding = '=' * (4 - (len(base64url_string) % 4))

--- a/server/key_attestation/openapi.yaml
+++ b/server/key_attestation/openapi.yaml
@@ -230,8 +230,10 @@ components:
       required:
         - session_id
         - encrypted_data
-        - client_public_key
         - salt
+        - certificate_chain
+        - device_info
+        - security_info
       properties:
         session_id:
           type: string
@@ -242,16 +244,18 @@ components:
           format: byte
           description: Base64URL-encoded (no padding) encrypted data.
           example: "SGVsbG8gV29ybGQ="
-        client_public_key:
-          type: string
-          format: base64
-          description: Standard Base64-encoded client's public key (X.509 SubjectPublicKeyInfo, DER).
-          example: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEE5g3G..."
         salt:
           type: string
           format: byte
           description: Base64URL-encoded (no padding) client-generated salt for HKDF.
           example: "Y2xpZW50X3NhbHRfZGF0YQ=="
+        certificate_chain:
+          type: array
+          items:
+            type: string
+            format: base64
+          description: Array of standard Base64-encoded certificate strings. The leaf certificate's public key is used for the key agreement.
+          example: [ "Y2VydDE=", "Y2VydDI=" ]
         device_info:
           $ref: '#/components/schemas/DeviceInfo'
         security_info:

--- a/server/key_attestation/tests/test_key_attestation.py
+++ b/server/key_attestation/tests/test_key_attestation.py
@@ -1,113 +1,113 @@
 import unittest
 import json
-import sys
-import os
-from unittest.mock import patch, MagicMock
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
 from key_attestation.key_attestation import app
-from key_attestation.utils import base64url_encode
-from key_attestation.datastore_utils import AGREEMENT_KEY_ATTESTATION_SESSION_KIND
+from key_attestation.cryptographic_utils import base64url_encode
+from unittest.mock import patch, MagicMock
+from google.cloud import datastore
 
 class KeyAttestationAgreementTest(unittest.TestCase):
+
     def setUp(self):
         self.app = app.test_client()
         self.app.testing = True
 
-    def tearDown(self):
-        pass
+        # Mock the datastore client
+        self.mock_datastore_client = MagicMock()
+        self.patcher = patch('key_attestation.key_attestation.datastore_client', self.mock_datastore_client)
+        self.patcher.start()
 
-    @patch('key_attestation.key_attestation.datastore_client', new_callable=MagicMock)
+    def tearDown(self):
+        self.patcher.stop()
+
     @patch('key_attestation.key_attestation.get_ds_agreement_key_attestation_session')
-    @patch('key_attestation.key_attestation.delete_ds_key_attestation_session')
-    @patch('key_attestation.key_attestation.store_ds_key_attestation_result')
     @patch('key_attestation.key_attestation.derive_shared_key')
     @patch('key_attestation.key_attestation.decrypt_data')
-    @patch('key_attestation.key_attestation.decode_certificate_chain')
     @patch('key_attestation.key_attestation.verify_certificate_chain')
     @patch('key_attestation.key_attestation.get_attestation_extension_properties')
-    def test_verify_agreement_success(self, mock_get_props, mock_verify_chain, mock_decode_chain, mock_decrypt, mock_derive_key, mock_store_result, mock_delete_session, mock_get_session, mock_ds_client):
-        # Mocking session data from Datastore
-        mock_session_entity = MagicMock()
-        mock_session_entity.get.side_effect = lambda key: {
-            'nonce': base64url_encode(b'test_nonce'),
-            'challenge': base64url_encode(b'test_challenge'),
-            'private_key': base64url_encode(b'test_server_private_key')
-        }.get(key)
-        mock_get_session.return_value = mock_session_entity
+    def test_verify_agreement_success(self, mock_get_attestation_extension_properties, mock_verify_certificate_chain, mock_decrypt_data, mock_derive_shared_key, mock_get_ds_agreement_key_attestation_session):
+        session_id = 'test_session_id'
+        nonce = 'test_nonce'
+        challenge = 'test_challenge'
+        server_private_key = 'test_server_private_key'
+        encrypted_data = 'test_encrypted_data'
+        salt = 'test_salt'
+        certificate_chain = ['cert1', 'cert2']
+        device_info = {'brand': 'Google', 'model': 'Pixel 7', 'device': 'panther', 'product': 'panther_us', 'manufacturer': 'Google', 'hardware': 'gs201', 'board': 'slider', 'bootloader': 'slider-1.0-...', 'version_release': '13', 'sdk_int': 33, 'fingerprint': 'google/panther/panther:13/...', 'security_patch': '2023-05-01'}
+        security_info = {'is_device_lock_enabled': True, 'is_biometrics_enabled': True, 'has_class_3_authenticator': True, 'has_strongbox': True}
 
-        # Mocking key derivation and decryption
-        mock_derive_key.return_value = b'test_aes_key'
-        mock_decrypt.return_value = b'test_nonce'
 
-        # Mocking certificate and attestation data
-        mock_decode_chain.return_value = [MagicMock()]
-        mock_verify_chain.return_value = True
-        mock_get_props.return_value = {
-            'attestation_challenge': b'test_challenge',
-            'attestation_version': 4,
-            'attestation_security_level': 1,
-            'keymint_or_keymaster_version': 4,
-            'keymint_or_keymaster_security_level': 1,
-            'software_enforced': {},
-            'hardware_enforced': {}
+        mock_get_ds_agreement_key_attestation_session.return_value = {
+            'nonce': base64url_encode(nonce.encode()),
+            'challenge': base64url_encode(challenge.encode()),
+            'private_key': base64url_encode(server_private_key.encode())
+        }
+        mock_derive_shared_key.return_value = b'test_aes_key'
+        mock_decrypt_data.return_value = nonce.encode()
+        mock_get_attestation_extension_properties.return_value = {
+            'attestation_challenge': challenge.encode()
         }
 
-        iv = base64url_encode(b'123456789012')
-        encrypted_data = base64url_encode(b'encrypted_nonce')
-        request_data = {
-            "session_id": "test_session_id",
-            "encrypted_data": f"{iv}{encrypted_data}",
-            "client_public_key": base64url_encode(b'test_client_public_key'),
-            "salt": base64url_encode(b'test_salt'),
-            "certificate_chain": [base64url_encode(b'test_cert')]
-        }
+        with patch('key_attestation.key_attestation.decode_certificate_chain') as mock_decode_certificate_chain:
+            mock_cert = MagicMock()
+            mock_public_key = MagicMock()
+            mock_public_key.public_bytes.return_value = b'test_public_key'
+            mock_cert.public_key.return_value = mock_public_key
+            mock_decode_certificate_chain.return_value = [mock_cert]
 
-        response = self.app.post('/v1/verify/agreement', data=json.dumps(request_data), content_type='application/json')
-        response_data = json.loads(response.data)
+            response = self.app.post('/v1/verify/agreement',
+                                     data=json.dumps({
+                                         'session_id': session_id,
+                                         'encrypted_data': base64url_encode(encrypted_data.encode()),
+                                         'salt': base64url_encode(salt.encode()),
+                                         'certificate_chain': certificate_chain,
+                                         'device_info': device_info,
+                                         'security_info': security_info
+                                     }),
+                                     content_type='application/json')
+            self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response_data['is_verified'])
-        mock_get_session.assert_called_once_with(unittest.mock.ANY, "test_session_id")
-        mock_delete_session.assert_called_once_with(unittest.mock.ANY, "test_session_id", AGREEMENT_KEY_ATTESTATION_SESSION_KIND)
-        mock_store_result.assert_called_once()
-
-    @patch('key_attestation.key_attestation.datastore_client', new_callable=MagicMock)
     @patch('key_attestation.key_attestation.get_ds_agreement_key_attestation_session')
-    @patch('key_attestation.key_attestation.delete_ds_key_attestation_session')
-    @patch('key_attestation.key_attestation.store_ds_key_attestation_result')
     @patch('key_attestation.key_attestation.derive_shared_key')
     @patch('key_attestation.key_attestation.decrypt_data')
-    def test_verify_agreement_nonce_mismatch(self, mock_decrypt, mock_derive_key, mock_store_result, mock_delete_session, mock_get_session, mock_ds_client):
-        # Mocking session data from Datastore
-        mock_session_entity = MagicMock()
-        mock_session_entity.get.side_effect = lambda key: {
-            'nonce': base64url_encode(b'test_nonce'),
-            'challenge': base64url_encode(b'test_challenge'),
-            'private_key': base64url_encode(b'test_server_private_key')
-        }.get(key)
-        mock_get_session.return_value = mock_session_entity
+    def test_verify_agreement_nonce_mismatch(self, mock_decrypt_data, mock_derive_shared_key, mock_get_ds_agreement_key_attestation_session):
+        session_id = 'test_session_id'
+        nonce = 'test_nonce'
+        challenge = 'test_challenge'
+        server_private_key = 'test_server_private_key'
+        encrypted_data = 'test_encrypted_data'
+        salt = 'test_salt'
+        certificate_chain = ['cert1', 'cert2']
+        device_info = {'brand': 'Google', 'model': 'Pixel 7', 'device': 'panther', 'product': 'panther_us', 'manufacturer': 'Google', 'hardware': 'gs201', 'board': 'slider', 'bootloader': 'slider-1.0-...', 'version_release': '13', 'sdk_int': 33, 'fingerprint': 'google/panther/panther:13/...', 'security_patch': '2023-05-01'}
+        security_info = {'is_device_lock_enabled': True, 'is_biometrics_enabled': True, 'has_class_3_authenticator': True, 'has_strongbox': True}
 
-        # Mocking key derivation and decryption for nonce mismatch
-        mock_derive_key.return_value = b'test_aes_key'
-        mock_decrypt.return_value = b'wrong_nonce'
-
-        iv = base64url_encode(b'123456789012')
-        encrypted_data = base64url_encode(b'encrypted_nonce')
-        request_data = {
-            "session_id": "test_session_id",
-            "encrypted_data": f"{iv}{encrypted_data}",
-            "client_public_key": base64url_encode(b'test_client_public_key'),
-            "salt": base64url_encode(b'test_salt'),
-            "certificate_chain": [base64url_encode(b'test_cert')]
+        mock_get_ds_agreement_key_attestation_session.return_value = {
+            'nonce': base64url_encode(nonce.encode()),
+            'challenge': base64url_encode(challenge.encode()),
+            'private_key': base64url_encode(server_private_key.encode())
         }
+        mock_derive_shared_key.return_value = b'test_aes_key'
+        mock_decrypt_data.return_value = b'wrong_nonce'
 
-        response = self.app.post('/v1/verify/agreement', data=json.dumps(request_data), content_type='application/json')
-        response_data = json.loads(response.data)
+        with patch('key_attestation.key_attestation.decode_certificate_chain') as mock_decode_certificate_chain:
+            mock_cert = MagicMock()
+            mock_public_key = MagicMock()
+            mock_public_key.public_bytes.return_value = b'test_public_key'
+            mock_cert.public_key.return_value = mock_public_key
+            mock_decode_certificate_chain.return_value = [mock_cert]
 
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('Nonce mismatch', response_data['error'])
-        mock_delete_session.assert_called_once_with(unittest.mock.ANY, "test_session_id", AGREEMENT_KEY_ATTESTATION_SESSION_KIND)
-        mock_store_result.assert_called_once()
+            response = self.app.post('/v1/verify/agreement',
+                                     data=json.dumps({
+                                         'session_id': session_id,
+                                         'encrypted_data': base64url_encode(encrypted_data.encode()),
+                                         'salt': base64url_encode(salt.encode()),
+                                         'certificate_chain': certificate_chain,
+                                         'device_info': device_info,
+                                         'security_info': security_info
+                                     }),
+                                     content_type='application/json')
+            response_data = json.loads(response.data)
+            self.assertEqual(response.status_code, 400)
+            self.assertIn('Nonce mismatch', response_data['error'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change adjusts the behavior of the `/verify/agreement` API for server-side key attestation.

Server-side changes:
- Removes the `client_public_key` request parameter.
- The leaf certificate (the first certificate in the `certificate_chain`) is now used as the client's public key.
- The OpenAPI definition has been updated to reflect these changes.

Android app changes:
- `VerifyAgreementRequest`:
    - Removed the `clientPublicKey` parameter.
    - Added the `certificateChainBase64Encoded` parameter.
    - Renamed `encryptedData` to `encryptedDataBase64UrlEncoded`.
    - Renamed `salt` to `saltBase64UrlEncoded`.
    - Made `deviceInfo` and `securityInfo` non-nullable.
- The "Request Verify KeyAttestation" button behavior has been updated to send the certificate chain of the generated key pair in the `certificate_chain` parameter of the `verifyAgreement` request.