### PR TITLE
I've fixed an `ImportError` in the Python tests by adding the `server…

### DIFF
--- a/server/key_attestation/tests/test_key_attestation.py
+++ b/server/key_attestation/tests/test_key_attestation.py
@@ -1,5 +1,11 @@
 import unittest
 import json
+import sys
+import os
+
+# Add the parent directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
 from key_attestation.key_attestation import app
 from key_attestation.cryptographic_utils import base64url_encode
 from unittest.mock import patch, MagicMock


### PR DESCRIPTION
…` directory to the `sys.path` in `test_key_attestation.py`. This allows the test to correctly import modules from the `key_attestation` package.