### PR TITLE
I will fix the Python test import error.

### DIFF
--- a/server/key_attestation/tests/test_key_attestation.py
+++ b/server/key_attestation/tests/test_key_attestation.py
@@ -1,5 +1,13 @@
 import unittest
 import json
+import sys
+import os
+
+# To allow imports from the 'server' directory, we add its parent to the Python path.
+# This ensures that 'from key_attestation...' works correctly, by making the 'server'
+# directory discoverable as a package source.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
 from key_attestation.key_attestation import app
 from key_attestation.cryptographic_utils import base64url_encode
 from unittest.mock import patch, MagicMock


### PR DESCRIPTION
To do this, I'll add the `server` directory's parent to the `sys.path`. This will ensure that the test runner can correctly locate and import modules from the `key_attestation` package, resolving relative import issues, especially when using `unittest discover`. I'll also add a comment to clarify the purpose of the `sys.path` modification.