### PR TITLE
Fix(android): Add info parameter to HKDF key derivation

### DIFF
--- a/android/app/src/main/java/dev/keiji/deviceintegrity/di/CryptoModule.kt
+++ b/android/app/src/main/java/dev/keiji/deviceintegrity/di/CryptoModule.kt
@@ -48,5 +48,8 @@ object CryptoModule {
 
     @Provides
     @Singleton
-    fun provideSharedKeyDerivator(): SharedKeyDerivator = HkdfKeyDerivator()
+    fun provideSharedKeyDerivator(): SharedKeyDerivator {
+        val hkdfInfo = "key-attestation-agreement".encodeToByteArray()
+        return HkdfKeyDerivator(hkdfInfo)
+    }
 }

--- a/android/crypto/impl/src/main/java/dev/keiji/deviceintegrity/crypto/impl/HkdfKeyDerivator.kt
+++ b/android/crypto/impl/src/main/java/dev/keiji/deviceintegrity/crypto/impl/HkdfKeyDerivator.kt
@@ -14,7 +14,9 @@ import javax.inject.Inject
  * Implements SharedKeyDerivator using HKDF (HMAC-based Key Derivation Function)
  * with standard Android APIs.
  */
-class HkdfKeyDerivator @Inject constructor() : SharedKeyDerivator {
+class HkdfKeyDerivator @Inject constructor(
+    private val hkdfInfo: ByteArray?
+) : SharedKeyDerivator {
 
     companion object {
         private const val KEY_AGREEMENT_ALGORITHM = "ECDH"
@@ -24,11 +26,20 @@ class HkdfKeyDerivator @Inject constructor() : SharedKeyDerivator {
     }
 
     override fun deriveKey(publicKey: PublicKey, privateKey: PrivateKey, salt: ByteArray?): ByteArray {
+        return deriveKey(publicKey, privateKey, salt, hkdfInfo)
+    }
+
+    private fun deriveKey(
+        publicKey: PublicKey,
+        privateKey: PrivateKey,
+        salt: ByteArray?,
+        info: ByteArray?
+    ): ByteArray {
         // 1. Perform Key Agreement (ECDH)
         val sharedSecret = performKeyAgreement(publicKey, privateKey)
 
         // 2. Perform HKDF (RFC 5869)
-        return hkdf(sharedSecret, salt, null, DERIVED_KEY_SIZE_BYTES)
+        return hkdf(sharedSecret, salt, info, DERIVED_KEY_SIZE_BYTES)
     }
 
     private fun performKeyAgreement(publicKey: PublicKey, privateKey: PrivateKey): ByteArray {

--- a/android/crypto/impl/src/test/java/dev/keiji/deviceintegrity/crypto/impl/HkdfKeyDerivatorTest.kt
+++ b/android/crypto/impl/src/test/java/dev/keiji/deviceintegrity/crypto/impl/HkdfKeyDerivatorTest.kt
@@ -25,7 +25,7 @@ class HkdfKeyDerivatorTest {
     @Before
     fun setUp() {
         // Security.addProvider(org.bouncycastle.jce.provider.BouncyCastleProvider()) // Not needed
-        derivator = HkdfKeyDerivator()
+        derivator = HkdfKeyDerivator(null)
     }
 
     private fun generateEcKeyPair(): KeyPair {


### PR DESCRIPTION
The HKDF key derivation on the app-side was missing the `info` parameter, which caused it to generate a different key than the server.

This change adds the `info` parameter to the app-side HKDF implementation to match the server's implementation.