### PR TITLE
feat: Convert KeyAttestation integer constants to strings

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -619,13 +619,31 @@ class KeyAttestationViewModel @Inject constructor(
 
         response.attestationInfo?.let { attestationInfo ->
             items.add(InfoItem("Attestation Version", attestationInfo.attestationVersion.toString()))
-            items.add(InfoItem("Attestation Security Level", attestationInfo.attestationSecurityLevel.toString()))
+            items.add(
+                InfoItem(
+                    "Attestation Security Level",
+                    ValueConverter.convertSecurityLevelToString(attestationInfo.attestationSecurityLevel)
+                )
+            )
             items.add(InfoItem("KeyMint Version", attestationInfo.keymintVersion.toString()))
-            items.add(InfoItem("KeyMint Security Level", attestationInfo.keymintSecurityLevel.toString()))
+            items.add(
+                InfoItem(
+                    "KeyMint Security Level",
+                    ValueConverter.convertSecurityLevelToString(attestationInfo.keymintSecurityLevel)
+                )
+            )
             items.add(InfoItem("Attestation Challenge", attestationInfo.attestationChallenge))
 
-            addAuthorizationListItems(items, "Software Enforced Properties", attestationInfo.softwareEnforcedProperties)
-            addAuthorizationListItems(items, "Hardware Enforced Properties", attestationInfo.hardwareEnforcedProperties)
+            addAuthorizationListItems(
+                items,
+                "Software Enforced Properties",
+                attestationInfo.softwareEnforcedProperties
+            )
+            addAuthorizationListItems(
+                items,
+                "Hardware Enforced Properties",
+                attestationInfo.hardwareEnforcedProperties
+            )
         }
         return items
     }
@@ -647,11 +665,20 @@ class KeyAttestationViewModel @Inject constructor(
             }
         }
         props.creationDatetime?.let { items.add(InfoItem("Creation Datetime", DateFormatUtil.formatEpochMilliToISO8601(it), indentLevel = 1)) }
-        props.algorithm?.let { items.add(InfoItem("Algorithm", it.toString(), indentLevel = 1)) }
-        props.origin?.let { items.add(InfoItem("Origin", it.toString(), indentLevel = 1)) }
+        props.algorithm?.let {
+            items.add(InfoItem("Algorithm", ValueConverter.convertAlgorithmToString(it), indentLevel = 1))
+        }
+        props.origin?.let {
+            items.add(InfoItem("Origin", ValueConverter.convertOriginToString(it), indentLevel = 1))
+        }
         props.ecCurve?.let { items.add(InfoItem("EC Curve", it.toString(), indentLevel = 1)) }
         props.keySize?.let { items.add(InfoItem("Key Size", it.toString(), indentLevel = 1)) }
-        props.purpose?.let { items.add(InfoItem("Purposes", it.joinToString(), indentLevel = 1)) }
+        props.purpose?.let {
+            val purposes = it.joinToString { purpose ->
+                ValueConverter.convertPurposeToString(purpose)
+            }
+            items.add(InfoItem("Purposes", purposes, indentLevel = 1))
+        }
         props.digest?.let { items.add(InfoItem("Digest", it.joinToString(), indentLevel = 1)) }
         props.padding?.let { items.add(InfoItem("Padding", it.joinToString(), indentLevel = 1)) }
         props.rsaPublicExponent?.let { items.add(InfoItem("RSA Public Exponent", it.toString(), indentLevel = 1)) }
@@ -673,7 +700,15 @@ class KeyAttestationViewModel @Inject constructor(
         props.rootOfTrust?.let { rot ->
             items.add(InfoItem("Root of Trust", "", indentLevel = 1, isHeader = true))
             rot.deviceLocked?.let { items.add(InfoItem("Device Locked", it.toString(), indentLevel = 2)) }
-            rot.verifiedBootState?.let { items.add(InfoItem("Verified Boot State", it.toString(), indentLevel = 2)) }
+            rot.verifiedBootState?.let {
+                items.add(
+                    InfoItem(
+                        "Verified Boot State",
+                        ValueConverter.convertVerifiedBootStateToString(it),
+                        indentLevel = 2
+                    )
+                )
+            }
             rot.verifiedBootHash?.let { items.add(InfoItem("Verified Boot Hash", it, indentLevel = 2)) }
             rot.verifiedBootKey?.let { items.add(InfoItem("Verified Boot Key", it, indentLevel = 2)) }
         }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/ValueConverter.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/ValueConverter.kt
@@ -1,0 +1,54 @@
+package dev.keiji.deviceintegrity.ui.main.keyattestation
+
+object ValueConverter {
+
+    fun convertSecurityLevelToString(value: Int): String {
+        return when (value) {
+            0 -> "Software(0)"
+            1 -> "TrustedEnvironment(1)"
+            2 -> "StrongBox(2)"
+            else -> value.toString()
+        }
+    }
+
+    fun convertVerifiedBootStateToString(value: Int): String {
+        return when (value) {
+            0 -> "Verified(0)"
+            1 -> "SelfSigned(1)"
+            2 -> "Unverified(2)"
+            3 -> "Failed(3)"
+            else -> value.toString()
+        }
+    }
+
+    fun convertAlgorithmToString(value: Int): String {
+        return when (value) {
+            1 -> "RSA(1)"
+            3 -> "EC(3)"
+            32 -> "AES(32)"
+            33 -> "TripleDES(33)"
+            128 -> "HMAC(128)"
+            else -> value.toString()
+        }
+    }
+
+    fun convertPurposeToString(value: Int): String {
+        return when (value) {
+            0 -> "ENCRYPT(0)"
+            1 -> "DECRYPT(1)"
+            2 -> "SIGN(2)"
+            3 -> "VERIFY(3)"
+            5 -> "WRAP_KEY(5)"
+            else -> value.toString()
+        }
+    }
+
+    fun convertOriginToString(value: Int): String {
+        return when (value) {
+            0 -> "GENERATED(0)"
+            1 -> "DERIVED(1)"
+            2 -> "IMPORTED(2)"
+            else -> value.toString()
+        }
+    }
+}


### PR DESCRIPTION
- Add ValueConverter to handle the conversion of integer constants to human-readable strings for KeyAttestation results.
- Update KeyAttestationViewModel to use ValueConverter for displaying Security Level, VerifiedBootState, Algorithm, Purpose, and Origin.