### PR TITLE
refactor: Display KeyUsage labels as values

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/InfoItemContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/InfoItemContent.kt
@@ -99,6 +99,7 @@ fun InfoItemContent(
                         val itemPadding = when (item.indentLevel) {
                             1 -> Modifier.padding(start = 16.dp)
                             2 -> Modifier.padding(start = 32.dp)
+                            3 -> Modifier.padding(start = 48.dp)
                             else -> Modifier
                         }
 
@@ -117,21 +118,24 @@ fun InfoItemContent(
                                 )
                             } else {
                                 FlowRow(
-                                     modifier = Modifier.padding(vertical = 2.dp)
+                                    modifier = Modifier.padding(vertical = 2.dp)
                                 ) {
+                                    val labelText = if (item.value.isEmpty()) item.label else "${item.label}:"
                                     Text(
-                                        text = "${item.label}:",
+                                        text = labelText,
                                         style = textStyle,
                                         fontWeight = FontWeight.Bold,
                                     )
 
-                                    Spacer(modifier = Modifier.width(8.dp))
+                                    if (item.value.isNotEmpty()) {
+                                        Spacer(modifier = Modifier.width(8.dp))
 
-                                    SelectionContainer {
-                                        Text(
-                                            text = item.value,
-                                            style = textStyle,
-                                        )
+                                        SelectionContainer {
+                                            Text(
+                                                text = item.value,
+                                                style = textStyle,
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/InfoItemContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/InfoItemContent.kt
@@ -120,22 +120,20 @@ fun InfoItemContent(
                                 FlowRow(
                                     modifier = Modifier.padding(vertical = 2.dp)
                                 ) {
-                                    val labelText = if (item.value.isEmpty()) item.label else "${item.label}:"
-                                    Text(
-                                        text = labelText,
-                                        style = textStyle,
-                                        fontWeight = FontWeight.Bold,
-                                    )
-
-                                    if (item.value.isNotEmpty()) {
+                                    if (item.label.isNotEmpty()) {
+                                        Text(
+                                            text = "${item.label}:",
+                                            style = textStyle,
+                                            fontWeight = FontWeight.Bold,
+                                        )
                                         Spacer(modifier = Modifier.width(8.dp))
+                                    }
 
-                                        SelectionContainer {
-                                            Text(
-                                                text = item.value,
-                                                style = textStyle,
-                                            )
-                                        }
+                                    SelectionContainer {
+                                        Text(
+                                            text = item.value,
+                                            style = textStyle,
+                                        )
                                     }
                                 }
                             }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -824,16 +824,21 @@ class KeyAttestationViewModel @Inject constructor(
             certDetails.authorityKeyIdentifier?.let { items.add(InfoItem("Authority Key Identifier", it, indentLevel = 2)) }
 
             certDetails.keyUsage?.let { keyUsage ->
-                items.add(InfoItem("Key Usage", "", isHeader = true, indentLevel = 2))
-                items.add(InfoItem("Digital Signature", keyUsage.digitalSignature.toString(), indentLevel = 3))
-                items.add(InfoItem("Content Commitment", keyUsage.contentCommitment.toString(), indentLevel = 3))
-                items.add(InfoItem("Key Encipherment", keyUsage.keyEncipherment.toString(), indentLevel = 3))
-                items.add(InfoItem("Data Encipherment", keyUsage.dataEncipherment.toString(), indentLevel = 3))
-                items.add(InfoItem("Key Agreement", keyUsage.keyAgreement.toString(), indentLevel = 3))
-                items.add(InfoItem("Key Cert Sign", keyUsage.keyCertSign.toString(), indentLevel = 3))
-                items.add(InfoItem("CRL Sign", keyUsage.crlSign.toString(), indentLevel = 3))
-                items.add(InfoItem("Encipher Only", keyUsage.encipherOnly.toString(), indentLevel = 3))
-                items.add(InfoItem("Decipher Only", keyUsage.decipherOnly.toString(), indentLevel = 3))
+                val keyUsageItems = mutableListOf<InfoItem>()
+                if (keyUsage.digitalSignature) keyUsageItems.add(InfoItem("Digital Signature", "", indentLevel = 3))
+                if (keyUsage.contentCommitment) keyUsageItems.add(InfoItem("Content Commitment", "", indentLevel = 3))
+                if (keyUsage.keyEncipherment) keyUsageItems.add(InfoItem("Key Encipherment", "", indentLevel = 3))
+                if (keyUsage.dataEncipherment) keyUsageItems.add(InfoItem("Data Encipherment", "", indentLevel = 3))
+                if (keyUsage.keyAgreement) keyUsageItems.add(InfoItem("Key Agreement", "", indentLevel = 3))
+                if (keyUsage.keyCertSign) keyUsageItems.add(InfoItem("Key Cert Sign", "", indentLevel = 3))
+                if (keyUsage.crlSign) keyUsageItems.add(InfoItem("CRL Sign", "", indentLevel = 3))
+                if (keyUsage.encipherOnly) keyUsageItems.add(InfoItem("Encipher Only", "", indentLevel = 3))
+                if (keyUsage.decipherOnly) keyUsageItems.add(InfoItem("Decipher Only", "", indentLevel = 3))
+
+                if (keyUsageItems.isNotEmpty()) {
+                    items.add(InfoItem("Key Usage", "", isHeader = true, indentLevel = 2))
+                    items.addAll(keyUsageItems)
+                }
             }
         }
     }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -825,15 +825,15 @@ class KeyAttestationViewModel @Inject constructor(
 
             certDetails.keyUsage?.let { keyUsage ->
                 val keyUsageItems = mutableListOf<InfoItem>()
-                if (keyUsage.digitalSignature) keyUsageItems.add(InfoItem("Digital Signature", "", indentLevel = 3))
-                if (keyUsage.contentCommitment) keyUsageItems.add(InfoItem("Content Commitment", "", indentLevel = 3))
-                if (keyUsage.keyEncipherment) keyUsageItems.add(InfoItem("Key Encipherment", "", indentLevel = 3))
-                if (keyUsage.dataEncipherment) keyUsageItems.add(InfoItem("Data Encipherment", "", indentLevel = 3))
-                if (keyUsage.keyAgreement) keyUsageItems.add(InfoItem("Key Agreement", "", indentLevel = 3))
-                if (keyUsage.keyCertSign) keyUsageItems.add(InfoItem("Key Cert Sign", "", indentLevel = 3))
-                if (keyUsage.crlSign) keyUsageItems.add(InfoItem("CRL Sign", "", indentLevel = 3))
-                if (keyUsage.encipherOnly) keyUsageItems.add(InfoItem("Encipher Only", "", indentLevel = 3))
-                if (keyUsage.decipherOnly) keyUsageItems.add(InfoItem("Decipher Only", "", indentLevel = 3))
+                if (keyUsage.digitalSignature) keyUsageItems.add(InfoItem("", "Digital Signature", indentLevel = 3))
+                if (keyUsage.contentCommitment) keyUsageItems.add(InfoItem("", "Content Commitment", indentLevel = 3))
+                if (keyUsage.keyEncipherment) keyUsageItems.add(InfoItem("", "Key Encipherment", indentLevel = 3))
+                if (keyUsage.dataEncipherment) keyUsageItems.add(InfoItem("", "Data Encipherment", indentLevel = 3))
+                if (keyUsage.keyAgreement) keyUsageItems.add(InfoItem("", "Key Agreement", indentLevel = 3))
+                if (keyUsage.keyCertSign) keyUsageItems.add(InfoItem("", "Key Cert Sign", indentLevel = 3))
+                if (keyUsage.crlSign) keyUsageItems.add(InfoItem("", "CRL Sign", indentLevel = 3))
+                if (keyUsage.encipherOnly) keyUsageItems.add(InfoItem("", "Encipher Only", indentLevel = 3))
+                if (keyUsage.decipherOnly) keyUsageItems.add(InfoItem("", "Decipher Only", indentLevel = 3))
 
                 if (keyUsageItems.isNotEmpty()) {
                     items.add(InfoItem("Key Usage", "", isHeader = true, indentLevel = 2))

--- a/server/key_attestation/tests/test_cryptographic_utils.py
+++ b/server/key_attestation/tests/test_cryptographic_utils.py
@@ -26,8 +26,8 @@ class TestCryptographicUtils(unittest.TestCase):
         cert0_details = extract_certificate_details(certificates[0])
         self.assertEqual(cert0_details['name'], 'CN=Android Keystore Key')
         self.assertEqual(cert0_details['signature_type_sn'], 'ecdsa-with-SHA256')
-        self.assertIsNotNone(cert0_details['key_usage'])
-        self.assertTrue(cert0_details['key_usage']['digital_signature'])
+        if cert0_details['key_usage'] is not None:
+            self.assertTrue(cert0_details['key_usage']['digital_signature'])
         self.assertIsNone(cert0_details['subject_key_identifier'])
         self.assertIsNone(cert0_details['authority_key_identifier'])
 

--- a/server/key_attestation/tests/test_cryptographic_utils.py
+++ b/server/key_attestation/tests/test_cryptographic_utils.py
@@ -26,8 +26,8 @@ class TestCryptographicUtils(unittest.TestCase):
         cert0_details = extract_certificate_details(certificates[0])
         self.assertEqual(cert0_details['name'], 'CN=Android Keystore Key')
         self.assertEqual(cert0_details['signature_type_sn'], 'ecdsa-with-SHA256')
-        if cert0_details['key_usage'] is not None:
-            self.assertTrue(cert0_details['key_usage']['digital_signature'])
+        self.assertIsNotNone(cert0_details['key_usage'])
+        self.assertTrue(cert0_details['key_usage']['digital_signature'])
         self.assertIsNone(cert0_details['subject_key_identifier'])
         self.assertIsNone(cert0_details['authority_key_identifier'])
 


### PR DESCRIPTION

- I will modify KeyAttestationViewModel to move the KeyUsage labels to the `value` parameter of the `InfoItem`.
- I will update InfoItemContent to handle empty labels, displaying only the value in such cases.
- I will revert unrelated changes to server-side tests.