### PR TITLE
feat: Unify waiting text

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -172,15 +172,19 @@ class KeyAttestationViewModel @Inject constructor(
             val totalSteps = (delayMs / PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
             var currentStep = 0
 
+            _uiState.update {
+                it.copy(
+                    status = "Waiting for ${delayMs / 1000} sec..."
+                )
+            }
+
             while (currentStep < totalSteps) {
                 delay(PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
                 currentStep++
                 val newProgress = PlayIntegrityProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps.toFloat())
-                val waitingTimeSec = (delayMs - (currentStep * PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)) / 1000.0
                 _uiState.update { currentState ->
                     currentState.copy(
                         progressValue = newProgress.coerceAtLeast(PlayIntegrityProgressConstants.NO_PROGRESS),
-                        status = "Waiting for ${String.format("%.1f", waitingTimeSec)}s..."
                     )
                 }
             }
@@ -343,15 +347,19 @@ class KeyAttestationViewModel @Inject constructor(
             val totalSteps = (delayMs / PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
             var currentStep = 0
 
+            _uiState.update {
+                it.copy(
+                    status = "Waiting for ${delayMs / 1000} sec..."
+                )
+            }
+
             while (currentStep < totalSteps) {
                 delay(PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
                 currentStep++
                 val newProgress = PlayIntegrityProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps.toFloat())
-                val waitingTimeSec = (delayMs - (currentStep * PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)) / 1000.0
                 _uiState.update { currentState ->
                     currentState.copy(
                         progressValue = newProgress.coerceAtLeast(PlayIntegrityProgressConstants.NO_PROGRESS),
-                        status = "Waiting for ${String.format("%.1f", waitingTimeSec)}s..."
                     )
                 }
             }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
@@ -285,7 +285,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         progressValue = PlayIntegrityProgressConstants.FULL_PROGRESS,
-                        status = "Waiting for ${delayMs / 1000} seconds before verification..."
+                        status = "Waiting for ${delayMs / 1000} sec..."
                     )
                 }
                 while (currentStep < totalSteps) {

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityViewModel.kt
@@ -233,7 +233,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         progressValue = PlayIntegrityProgressConstants.FULL_PROGRESS,
-                        status = "Waiting for ${delayMs / 1000} seconds before verification..."
+                        status = "Waiting for ${delayMs / 1000} sec..."
                     )
                 }
                 while (currentStep < totalSteps) {


### PR DESCRIPTION
Unify the text displayed during the waiting time before server communication to "Waiting for x sec...".

The value of x is fixed and does not update with the remaining time. The HorizontalProgressBar is responsible for indicating the progress, so the text only needs to show the total waiting duration.