### PR TITLE
Refactor: Move common UI components to the :ui module

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationScreen.kt
@@ -32,9 +32,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import dev.keiji.deviceintegrity.ui.main.InfoItem
-import dev.keiji.deviceintegrity.ui.main.InfoItemContent
-import dev.keiji.deviceintegrity.ui.main.playintegrity.PlayIntegrityProgressConstants
+import dev.keiji.deviceintegrity.ui.common.InfoItem
+import dev.keiji.deviceintegrity.ui.common.InfoItemContent
+import dev.keiji.deviceintegrity.ui.main.playintegrity.ProgressConstants
 import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -54,7 +54,7 @@ fun KeyAttestationScreen(
     val keyTypes = CryptoAlgorithm.values().toList()
 
     val isHorizontalProgressVisible =
-        uiState.progressValue != PlayIntegrityProgressConstants.NO_PROGRESS
+        uiState.progressValue != ProgressConstants.NO_PROGRESS
 
     val step2Label = when (uiState.selectedKeyType) {
         CryptoAlgorithm.ECDH -> "Step 2. サーバーからNonce/Challenge/PublicKeyを取得"
@@ -191,7 +191,7 @@ fun KeyAttestationScreen(
 
         // Progress Indicator
         if (isHorizontalProgressVisible) {
-            val progress = if (uiState.progressValue == PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS) {
+            val progress = if (uiState.progressValue == ProgressConstants.INDETERMINATE_PROGRESS) {
                 null
             } else {
                 uiState.progressValue

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationUiState.kt
@@ -1,8 +1,8 @@
 package dev.keiji.deviceintegrity.ui.main.keyattestation
 
 import dev.keiji.deviceintegrity.repository.contract.KeyPairData
-import dev.keiji.deviceintegrity.ui.main.InfoItem
-import dev.keiji.deviceintegrity.ui.main.playintegrity.PlayIntegrityProgressConstants
+import dev.keiji.deviceintegrity.ui.common.InfoItem
+import dev.keiji.deviceintegrity.ui.main.playintegrity.ProgressConstants
 
 data class KeyAttestationUiState(
     val nonce: String = "",
@@ -12,7 +12,7 @@ data class KeyAttestationUiState(
     val infoItems: List<InfoItem> = emptyList(), // Renamed field for structured results
     val sessionId: String? = null,
     val generatedKeyPairData: KeyPairData? = null,
-    val progressValue: Float = PlayIntegrityProgressConstants.NO_PROGRESS,
+    val progressValue: Float = ProgressConstants.NO_PROGRESS,
     val isEcdhAvailable: Boolean = false,
     val serverPublicKey: String = "",
     val isStrongboxSupported: Boolean = false,
@@ -22,7 +22,7 @@ data class KeyAttestationUiState(
     val isChallengeVisible: Boolean get() = challenge.isNotEmpty()
 
     val isLoading: Boolean
-        get() = progressValue != PlayIntegrityProgressConstants.NO_PROGRESS
+        get() = progressValue != ProgressConstants.NO_PROGRESS
 
     // Step 1 is now Key Selection, enabled if not loading
     val isStep1KeySelectionEnabled: Boolean get() = !isLoading

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/keyattestation/KeyAttestationViewModel.kt
@@ -17,10 +17,10 @@ import dev.keiji.deviceintegrity.provider.contract.DeviceSecurityStateProvider
 import dev.keiji.deviceintegrity.repository.contract.KeyPairRepository
 import dev.keiji.deviceintegrity.repository.contract.KeyAttestationRepository
 import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
-import dev.keiji.deviceintegrity.ui.main.InfoItem
+import dev.keiji.deviceintegrity.ui.common.InfoItem
 import dev.keiji.deviceintegrity.ui.main.common.KEY_ATTESTATION_DELAY_MS
-import dev.keiji.deviceintegrity.ui.main.playintegrity.PlayIntegrityProgressConstants
-import dev.keiji.deviceintegrity.ui.main.util.Base64Utils
+import dev.keiji.deviceintegrity.ui.main.playintegrity.ProgressConstants
+import dev.keiji.deviceintegrity.ui.util.Base64Utils
 import dev.keiji.deviceintegrity.ui.main.util.DateFormatUtil
 import dev.keiji.deviceintegrity.ui.main.util.KeyUtils
 import kotlinx.coroutines.Dispatchers
@@ -93,7 +93,7 @@ class KeyAttestationViewModel @Inject constructor(
                         }
                         "Key algorithm changed to ${newKeyType.label}. Please fetch new $itemsToFetch."
                     },
-                    progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                    progressValue = ProgressConstants.NO_PROGRESS,
                     sessionId = null
                 )
             }
@@ -123,7 +123,7 @@ class KeyAttestationViewModel @Inject constructor(
                     generatedKeyPairData = null,
                     infoItems = emptyList(),
                     status = "StrongBox preference changed. Please generate a new key pair.",
-                    progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                    progressValue = ProgressConstants.NO_PROGRESS,
                 )
             }
         }
@@ -164,12 +164,12 @@ class KeyAttestationViewModel @Inject constructor(
                     serverPublicKey = "",
                     generatedKeyPairData = null,
                     infoItems = emptyList(),
-                    progressValue = PlayIntegrityProgressConstants.FULL_PROGRESS
+                    progressValue = ProgressConstants.FULL_PROGRESS
                 )
             }
 
             val delayMs = KEY_ATTESTATION_DELAY_MS
-            val totalSteps = (delayMs / PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
+            val totalSteps = (delayMs / ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
             var currentStep = 0
 
             _uiState.update {
@@ -179,12 +179,12 @@ class KeyAttestationViewModel @Inject constructor(
             }
 
             while (currentStep < totalSteps) {
-                delay(PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
+                delay(ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
                 currentStep++
-                val newProgress = PlayIntegrityProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps.toFloat())
+                val newProgress = ProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps.toFloat())
                 _uiState.update { currentState ->
                     currentState.copy(
-                        progressValue = newProgress.coerceAtLeast(PlayIntegrityProgressConstants.NO_PROGRESS),
+                        progressValue = newProgress.coerceAtLeast(ProgressConstants.NO_PROGRESS),
                     )
                 }
             }
@@ -192,7 +192,7 @@ class KeyAttestationViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     status = fetchingMessage,
-                    progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS
+                    progressValue = ProgressConstants.INDETERMINATE_PROGRESS
                 )
             }
 
@@ -209,7 +209,7 @@ class KeyAttestationViewModel @Inject constructor(
                             challenge = response.challengeBase64UrlEncoded,
                             serverPublicKey = response.publicKeyBase64UrlEncoded,
                             status = successMessage,
-                            progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                            progressValue = ProgressConstants.NO_PROGRESS
                         )
                     }
                 } else {
@@ -220,7 +220,7 @@ class KeyAttestationViewModel @Inject constructor(
                             nonce = response.nonceBase64UrlEncoded,
                             challenge = response.challengeBase64UrlEncoded,
                             status = successMessage,
-                            progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                            progressValue = ProgressConstants.NO_PROGRESS
                         )
                     }
                 }
@@ -231,7 +231,7 @@ class KeyAttestationViewModel @Inject constructor(
                     it.copy(
                         status = "$failureMessagePrefix: Server Error ${e.errorCode ?: ""}: $message",
                         sessionId = null,
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
             } catch (e: IOException) {
@@ -240,7 +240,7 @@ class KeyAttestationViewModel @Inject constructor(
                     it.copy(
                         status = "$failureMessagePrefix: Network Error: ${e.localizedMessage}",
                         sessionId = null,
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
             } catch (e: Exception) {
@@ -249,7 +249,7 @@ class KeyAttestationViewModel @Inject constructor(
                     it.copy(
                         status = "$failureMessagePrefix: ${e.localizedMessage}",
                         sessionId = null,
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
             }
@@ -263,7 +263,7 @@ class KeyAttestationViewModel @Inject constructor(
                     status = "Generating KeyPair...",
                     generatedKeyPairData = null,
                     infoItems = emptyList(),
-                    progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS
+                    progressValue = ProgressConstants.INDETERMINATE_PROGRESS
                 )
             }
 
@@ -280,7 +280,7 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         status = "$missingItem is not available. Fetch $missingItem/Challenge$suffix first.",
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
                 return@launch
@@ -317,7 +317,7 @@ class KeyAttestationViewModel @Inject constructor(
                     it.copy(
                         generatedKeyPairData = keyPairDataResult,
                         status = "KeyPair generated successfully. Alias: ${keyPairDataResult.keyAlias}",
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
             } catch (e: Exception) {
@@ -326,7 +326,7 @@ class KeyAttestationViewModel @Inject constructor(
                     it.copy(
                         status = "Failed to generate KeyPair: ${e.message}",
                         generatedKeyPairData = null,
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
             }
@@ -339,12 +339,12 @@ class KeyAttestationViewModel @Inject constructor(
                 it.copy(
                     status = "Preparing to verify KeyAttestation...",
                     infoItems = emptyList(),
-                    progressValue = PlayIntegrityProgressConstants.FULL_PROGRESS
+                    progressValue = ProgressConstants.FULL_PROGRESS
                 )
             }
 
             val delayMs = KEY_ATTESTATION_DELAY_MS
-            val totalSteps = (delayMs / PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
+            val totalSteps = (delayMs / ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
             var currentStep = 0
 
             _uiState.update {
@@ -354,12 +354,12 @@ class KeyAttestationViewModel @Inject constructor(
             }
 
             while (currentStep < totalSteps) {
-                delay(PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
+                delay(ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
                 currentStep++
-                val newProgress = PlayIntegrityProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps.toFloat())
+                val newProgress = ProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps.toFloat())
                 _uiState.update { currentState ->
                     currentState.copy(
-                        progressValue = newProgress.coerceAtLeast(PlayIntegrityProgressConstants.NO_PROGRESS),
+                        progressValue = newProgress.coerceAtLeast(ProgressConstants.NO_PROGRESS),
                     )
                 }
             }
@@ -367,7 +367,7 @@ class KeyAttestationViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     status = "Verifying KeyAttestation...",
-                    progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS
+                    progressValue = ProgressConstants.INDETERMINATE_PROGRESS
                 )
             }
 
@@ -382,7 +382,7 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         status = "SessionId is missing. Fetch $itemToFetch first.",
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
                 return@launch
@@ -393,7 +393,7 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         status = "KeyPair is not generated yet.",
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
                 return@launch
@@ -405,7 +405,7 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         status = "Server $missingItem is missing. Fetch $missingItem/Challenge$suffix first.",
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
                 return@launch
@@ -417,7 +417,7 @@ class KeyAttestationViewModel @Inject constructor(
                         _uiState.update {
                             it.copy(
                                 status = "Server PublicKey or Challenge is missing for ECDH. Fetch Nonce/Challenge/PublicKey first.",
-                                progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                                progressValue = ProgressConstants.NO_PROGRESS
                             )
                         }
                         return@launch
@@ -478,14 +478,14 @@ class KeyAttestationViewModel @Inject constructor(
                             it.copy(
                                 status = "Verification successful.",
                                 infoItems = resultItems,
-                                progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                                progressValue = ProgressConstants.NO_PROGRESS
                             )
                         }
                     } else {
                         _uiState.update {
                             it.copy(
                                 status = "Verification failed. Reason: ${response.reason ?: "Unknown"}",
-                                progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                                progressValue = ProgressConstants.NO_PROGRESS
                             )
                         }
                     }
@@ -503,7 +503,7 @@ class KeyAttestationViewModel @Inject constructor(
                             _uiState.update {
                                 it.copy(
                                     status = "Unsupported algorithm for signing.",
-                                    progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                                    progressValue = ProgressConstants.NO_PROGRESS
                                 )
                             }
                             return@launch
@@ -552,14 +552,14 @@ class KeyAttestationViewModel @Inject constructor(
                             it.copy(
                                 status = "Verification successful.",
                                 infoItems = resultItems,
-                                progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                                progressValue = ProgressConstants.NO_PROGRESS
                             )
                         }
                     } else {
                         _uiState.update {
                             it.copy(
                                 status = "Verification failed. Reason: ${responseVerifySignature.reason ?: "Unknown"}",
-                                progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                                progressValue = ProgressConstants.NO_PROGRESS
                             )
                         }
                     }
@@ -570,7 +570,7 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         status = "Failed to verify KeyAttestation: Server Error ${e.errorCode ?: ""}: $message",
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
             } catch (e: IOException) {
@@ -578,7 +578,7 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         status = "Failed to verify KeyAttestation: Network Error: ${e.localizedMessage}",
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
             } catch (e: Exception) {
@@ -586,7 +586,7 @@ class KeyAttestationViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         status = "Failed to verify KeyAttestation: ${e.localizedMessage}",
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS
+                        progressValue = ProgressConstants.NO_PROGRESS
                     )
                 }
             }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityContent.kt
@@ -27,9 +27,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import dev.keiji.deviceintegrity.ui.main.InfoItem
-import dev.keiji.deviceintegrity.ui.main.InfoItemContent
-import dev.keiji.deviceintegrity.ui.main.keyattestation.InfoItemFormatter
+import dev.keiji.deviceintegrity.ui.common.InfoItem
+import dev.keiji.deviceintegrity.ui.common.InfoItemContent
+import dev.keiji.deviceintegrity.ui.common.InfoItemFormatter
 import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 import kotlinx.coroutines.launch
 
@@ -102,10 +102,10 @@ fun ClassicPlayIntegrityContent(
 
         // Progress Indicators
         val isProgressVisible =
-            uiState.progressValue != PlayIntegrityProgressConstants.NO_PROGRESS
+            uiState.progressValue != ProgressConstants.NO_PROGRESS
 
         if (isProgressVisible) {
-            val progress = if (uiState.progressValue == PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS) {
+            val progress = if (uiState.progressValue == ProgressConstants.INDETERMINATE_PROGRESS) {
                 null
             } else {
                 uiState.progressValue

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityUiState.kt
@@ -2,13 +2,13 @@ package dev.keiji.deviceintegrity.ui.main.playintegrity
 
 import dev.keiji.deviceintegrity.api.playintegrity.ServerVerificationPayload
 import dev.keiji.deviceintegrity.provider.contract.GooglePlayDeveloperServiceInfo
-import dev.keiji.deviceintegrity.ui.main.InfoItem
-import dev.keiji.deviceintegrity.ui.main.playintegrity.PlayIntegrityProgressConstants // Import statement added
+import dev.keiji.deviceintegrity.ui.common.InfoItem
+import dev.keiji.deviceintegrity.ui.main.playintegrity.ProgressConstants // Import statement added
 
 data class ClassicPlayIntegrityUiState(
     val nonce: String = "",
     val integrityToken: String = "",
-    val progressValue: Float = PlayIntegrityProgressConstants.NO_PROGRESS,
+    val progressValue: Float = ProgressConstants.NO_PROGRESS,
     val status: String = "",
     val serverVerificationPayload: ServerVerificationPayload? = null, // Keep for now, maybe used by other logic
     val googlePlayDeveloperServiceInfo: GooglePlayDeveloperServiceInfo? = null,
@@ -17,7 +17,7 @@ data class ClassicPlayIntegrityUiState(
     val resultInfoItems: List<InfoItem> = emptyList() // New field
 ) {
     val isLoading: Boolean
-        get() = progressValue != PlayIntegrityProgressConstants.NO_PROGRESS
+        get() = progressValue != ProgressConstants.NO_PROGRESS
 
     val isFetchNonceButtonEnabled: Boolean
         get() = !isLoading

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModel.kt
@@ -16,7 +16,7 @@ import dev.keiji.deviceintegrity.repository.contract.PlayIntegrityRepository
 import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
 import dev.keiji.deviceintegrity.ui.main.common.DEBUG_VERIFY_TOKEN_DELAY_MS
 import dev.keiji.deviceintegrity.ui.main.common.VERIFY_TOKEN_DELAY_MS
-import dev.keiji.deviceintegrity.ui.main.InfoItem // Moved to top
+import dev.keiji.deviceintegrity.ui.common.InfoItem // Moved to top
 import dev.keiji.deviceintegrity.ui.main.util.DateFormatUtil // Moved to top
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,7 +28,7 @@ import java.io.IOException
 import java.util.UUID
 import javax.inject.Inject
 
-// PlayIntegrityProgressConstants will be imported from the new common file
+// ProgressConstants will be imported from the new common file
 
 @HiltViewModel
 class ClassicPlayIntegrityViewModel @Inject constructor(
@@ -56,7 +56,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 integrityToken = "",
-                progressValue = PlayIntegrityProgressConstants.FULL_PROGRESS,
+                progressValue = ProgressConstants.FULL_PROGRESS,
                 status = "Fetching nonce from server...",
                 serverVerificationPayload = null,
                 resultInfoItems = emptyList(), // Clear previous results
@@ -66,27 +66,27 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val delayMs = VERIFY_TOKEN_DELAY_MS
-                val totalSteps = (delayMs / PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
+                val totalSteps = (delayMs / ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
                 var currentStep = 0
                 while (currentStep < totalSteps) {
-                    delay(PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
+                    delay(ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
                     currentStep++
                     if (currentStep < totalSteps) {
-                        val newProgress = PlayIntegrityProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps)
+                        val newProgress = ProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps)
                         _uiState.update { currentState ->
-                            currentState.copy(progressValue = newProgress.coerceAtLeast(PlayIntegrityProgressConstants.NO_PROGRESS))
+                            currentState.copy(progressValue = newProgress.coerceAtLeast(ProgressConstants.NO_PROGRESS))
                         }
                     }
                 }
                 _uiState.update { it.copy(
-                    progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS,
+                    progressValue = ProgressConstants.INDETERMINATE_PROGRESS,
                     status = "Finalizing nonce request..."
                 ) }
                 val response = playIntegrityRepository.getNonce(currentSessionId)
                 _uiState.update {
                     it.copy(
                         nonce = response.nonce,
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         status = "Nonce fetched: ${response.nonce}",
                         currentSessionId = currentSessionId
                     )
@@ -97,7 +97,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Server error fetching nonce: ${e.errorMessage ?: "Unknown"}"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage), // For test assertion on errorMessages.first()
                         resultInfoItems = emptyList()
@@ -109,7 +109,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Network error fetching nonce: $specificErrorMessage"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage), // For test assertion on errorMessages.first()
                         resultInfoItems = emptyList()
@@ -121,7 +121,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Unknown error fetching nonce: $specificErrorMessage"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage),
                         resultInfoItems = emptyList()
@@ -224,7 +224,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
         }
         _uiState.update {
             it.copy(
-                progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS,
+                progressValue = ProgressConstants.INDETERMINATE_PROGRESS,
                 status = "Fetching token...",
                 errorMessages = emptyList(),
                 resultInfoItems = emptyList(), // Clear previous results
@@ -237,7 +237,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 Log.d("ClassicPlayIntegrityVM", "Integrity Token: $token")
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         integrityToken = token,
                         status = "Token fetched successfully (see Logcat for token)",
                         errorMessages = emptyList()
@@ -248,7 +248,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 val errorStatus = "Error fetching integrity token: ${e.message ?: "Unknown error."}"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         status = errorStatus,
                         errorMessages = listOfNotNull(e.message)
                     )
@@ -270,7 +270,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
         }
         _uiState.update {
             it.copy(
-                progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS,
+                progressValue = ProgressConstants.INDETERMINATE_PROGRESS,
                 status = "Preparing to verify token...",
                 errorMessages = emptyList(),
                 resultInfoItems = emptyList(), // Clear previous results
@@ -280,25 +280,25 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val delayMs = if (appInfoProvider.isDebugBuild) DEBUG_VERIFY_TOKEN_DELAY_MS else VERIFY_TOKEN_DELAY_MS
-                val totalSteps = (delayMs / PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
+                val totalSteps = (delayMs / ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
                 var currentStep = 0
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.FULL_PROGRESS,
+                        progressValue = ProgressConstants.FULL_PROGRESS,
                         status = "Waiting for ${delayMs / 1000} sec..."
                     )
                 }
                 while (currentStep < totalSteps) {
-                    delay(PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
+                    delay(ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
                     currentStep++
-                    val newProgress = PlayIntegrityProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps)
+                    val newProgress = ProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps)
                     _uiState.update {
-                        it.copy(progressValue = newProgress.coerceAtLeast(PlayIntegrityProgressConstants.NO_PROGRESS))
+                        it.copy(progressValue = newProgress.coerceAtLeast(ProgressConstants.NO_PROGRESS))
                     }
                 }
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS,
+                        progressValue = ProgressConstants.INDETERMINATE_PROGRESS,
                         status = "Now verifying token with server..."
                     )
                 }
@@ -322,7 +322,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 val finalStatus = "Token verification complete."
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         status = finalStatus,
                         serverVerificationPayload = verifyResponse,
                         resultInfoItems = resultItems,
@@ -336,7 +336,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Server error verifying token: ${e.errorMessage ?: "Unknown"}"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS, status = userFacingStatus,
+                        progressValue = ProgressConstants.NO_PROGRESS, status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage), serverVerificationPayload = null, resultInfoItems = emptyList()
                     )
                 }
@@ -346,7 +346,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Network error verifying token: $specificErrorMessage"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS, status = userFacingStatus,
+                        progressValue = ProgressConstants.NO_PROGRESS, status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage), serverVerificationPayload = null, resultInfoItems = emptyList()
                     )
                 }
@@ -356,7 +356,7 @@ class ClassicPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Unknown error verifying token: $specificErrorMessage"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS, status = userFacingStatus,
+                        progressValue = ProgressConstants.NO_PROGRESS, status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage), serverVerificationPayload = null, resultInfoItems = emptyList()
                     )
                 }

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityContent.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityContent.kt
@@ -28,9 +28,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import dev.keiji.deviceintegrity.ui.main.InfoItem
-import dev.keiji.deviceintegrity.ui.main.InfoItemContent
-import dev.keiji.deviceintegrity.ui.main.keyattestation.InfoItemFormatter
+import dev.keiji.deviceintegrity.ui.common.InfoItem
+import dev.keiji.deviceintegrity.ui.common.InfoItemContent
+import dev.keiji.deviceintegrity.ui.common.InfoItemFormatter
 import dev.keiji.deviceintegrity.ui.theme.ButtonHeight
 import kotlinx.coroutines.launch
 
@@ -104,10 +104,10 @@ fun StandardPlayIntegrityContent(
 
         // Progress Indicators
         val isProgressVisible =
-            uiState.progressValue != PlayIntegrityProgressConstants.NO_PROGRESS
+            uiState.progressValue != ProgressConstants.NO_PROGRESS
 
         if (isProgressVisible) {
-            val progress = if (uiState.progressValue == PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS) {
+            val progress = if (uiState.progressValue == ProgressConstants.INDETERMINATE_PROGRESS) {
                 null
             } else {
                 uiState.progressValue

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityUiState.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityUiState.kt
@@ -2,12 +2,12 @@ package dev.keiji.deviceintegrity.ui.main.playintegrity
 
 import dev.keiji.deviceintegrity.api.playintegrity.ServerVerificationPayload
 import dev.keiji.deviceintegrity.provider.contract.GooglePlayDeveloperServiceInfo
-import dev.keiji.deviceintegrity.ui.main.InfoItem
+import dev.keiji.deviceintegrity.ui.common.InfoItem
 
 data class StandardPlayIntegrityUiState(
     val contentBinding: String = "",
     val integrityToken: String = "",
-    val progressValue: Float = PlayIntegrityProgressConstants.NO_PROGRESS,
+    val progressValue: Float = ProgressConstants.NO_PROGRESS,
     val status: String = "",
     val serverVerificationPayload: ServerVerificationPayload? = null, // Keep for now
     val errorMessages: List<String> = emptyList(), // Will be combined into status
@@ -17,7 +17,7 @@ data class StandardPlayIntegrityUiState(
     val resultInfoItems: List<InfoItem> = emptyList() // New field
 ) {
     val isLoading: Boolean
-        get() = progressValue != PlayIntegrityProgressConstants.NO_PROGRESS
+        get() = progressValue != ProgressConstants.NO_PROGRESS
 
     val requestHashVisible: Boolean
         get() = requestHashValue.isNotEmpty()

--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityViewModel.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/playintegrity/StandardPlayIntegrityViewModel.kt
@@ -16,7 +16,7 @@ import dev.keiji.deviceintegrity.repository.contract.PlayIntegrityRepository
 import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
 import dev.keiji.deviceintegrity.ui.main.common.DEBUG_VERIFY_TOKEN_DELAY_MS
 import dev.keiji.deviceintegrity.ui.main.common.VERIFY_TOKEN_DELAY_MS
-import dev.keiji.deviceintegrity.ui.main.InfoItem // Correctly at top
+import dev.keiji.deviceintegrity.ui.common.InfoItem // Correctly at top
 import dev.keiji.deviceintegrity.ui.main.util.DateFormatUtil // Correctly at top
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,7 +30,7 @@ import java.io.IOException
 import java.util.UUID
 import javax.inject.Inject
 
-// PlayIntegrityProgressConstants will be imported from the new common file
+// ProgressConstants will be imported from the new common file
 
 @HiltViewModel
 class StandardPlayIntegrityViewModel @Inject constructor(
@@ -157,7 +157,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
         }
         _uiState.update {
             it.copy(
-                progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS,
+                progressValue = ProgressConstants.INDETERMINATE_PROGRESS,
                 status = "Fetching token...",
                 requestHashValue = "",
                 errorMessages = emptyList(),
@@ -172,7 +172,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 Log.d("StandardPlayIntegrityVM", "Integrity Token (Standard): $token")
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         integrityToken = token,
                         status = "Token fetched successfully (Standard API, see Logcat for token)",
                         errorMessages = emptyList(),
@@ -190,7 +190,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Error fetching integrity token (Standard): ${e.message ?: "Unknown error"}"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS,
+                        progressValue = ProgressConstants.NO_PROGRESS,
                         status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage),
                         requestHashValue = ""
@@ -217,7 +217,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
         }
         _uiState.update {
             it.copy(
-                progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS,
+                progressValue = ProgressConstants.INDETERMINATE_PROGRESS,
                 status = "Preparing to verify token...",
                 errorMessages = emptyList(),
                 resultInfoItems = emptyList(),
@@ -228,25 +228,25 @@ class StandardPlayIntegrityViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val delayMs = if (appInfoProvider.isDebugBuild) DEBUG_VERIFY_TOKEN_DELAY_MS else VERIFY_TOKEN_DELAY_MS
-                val totalSteps = (delayMs / PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
+                val totalSteps = (delayMs / ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS).toInt()
                 var currentStep = 0
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.FULL_PROGRESS,
+                        progressValue = ProgressConstants.FULL_PROGRESS,
                         status = "Waiting for ${delayMs / 1000} sec..."
                     )
                 }
                 while (currentStep < totalSteps) {
-                    delay(PlayIntegrityProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
+                    delay(ProgressConstants.PROGRESS_UPDATE_INTERVAL_MS)
                     currentStep++
-                    val newProgress = PlayIntegrityProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps)
+                    val newProgress = ProgressConstants.FULL_PROGRESS - (currentStep.toFloat() / totalSteps)
                     _uiState.update {
-                        it.copy(progressValue = newProgress.coerceAtLeast(PlayIntegrityProgressConstants.NO_PROGRESS))
+                        it.copy(progressValue = newProgress.coerceAtLeast(ProgressConstants.NO_PROGRESS))
                     }
                 }
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.INDETERMINATE_PROGRESS,
+                        progressValue = ProgressConstants.INDETERMINATE_PROGRESS,
                         status = "Now verifying token with server..."
                     )
                 }
@@ -269,7 +269,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 val finalStatus = "Token verification complete."
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS, status = finalStatus,
+                        progressValue = ProgressConstants.NO_PROGRESS, status = finalStatus,
                         serverVerificationPayload = response, resultInfoItems = resultItems,
                         errorMessages = emptyList(), currentSessionId = currentSessionId
                     )
@@ -280,7 +280,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Server error verifying token: ${e.errorMessage ?: "Unknown"}"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS, status = userFacingStatus,
+                        progressValue = ProgressConstants.NO_PROGRESS, status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage), serverVerificationPayload = null, resultInfoItems = emptyList()
                     )
                 }
@@ -290,7 +290,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Network error verifying token: $specificErrorMessage"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS, status = userFacingStatus,
+                        progressValue = ProgressConstants.NO_PROGRESS, status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage), serverVerificationPayload = null, resultInfoItems = emptyList()
                     )
                 }
@@ -300,7 +300,7 @@ class StandardPlayIntegrityViewModel @Inject constructor(
                 val userFacingStatus = "Unknown error verifying token: $specificErrorMessage"
                 _uiState.update {
                     it.copy(
-                        progressValue = PlayIntegrityProgressConstants.NO_PROGRESS, status = userFacingStatus,
+                        progressValue = ProgressConstants.NO_PROGRESS, status = userFacingStatus,
                         errorMessages = listOf(specificErrorMessage), serverVerificationPayload = null, resultInfoItems = emptyList()
                     )
                 }

--- a/android/ui/src/main/java/dev/keiji/deviceintegrity/ui/common/InfoItem.kt
+++ b/android/ui/src/main/java/dev/keiji/deviceintegrity/ui/common/InfoItem.kt
@@ -1,4 +1,4 @@
-package dev.keiji.deviceintegrity.ui.main
+package dev.keiji.deviceintegrity.ui.common
 
 data class InfoItem(
     val label: String,

--- a/android/ui/src/main/java/dev/keiji/deviceintegrity/ui/common/InfoItemFormatter.kt
+++ b/android/ui/src/main/java/dev/keiji/deviceintegrity/ui/common/InfoItemFormatter.kt
@@ -1,6 +1,6 @@
-package dev.keiji.deviceintegrity.ui.main.keyattestation
+package dev.keiji.deviceintegrity.ui.common
 
-import dev.keiji.deviceintegrity.ui.main.InfoItem
+import dev.keiji.deviceintegrity.ui.common.InfoItem
 
 object InfoItemFormatter {
     fun formatInfoItems(items: List<InfoItem>): String {

--- a/android/ui/src/main/java/dev/keiji/deviceintegrity/ui/common/ProgressConstants.kt
+++ b/android/ui/src/main/java/dev/keiji/deviceintegrity/ui/common/ProgressConstants.kt
@@ -1,6 +1,6 @@
-package dev.keiji.deviceintegrity.ui.main.playintegrity
+package dev.keiji.deviceintegrity.ui.common
 
-object PlayIntegrityProgressConstants {
+object ProgressConstants {
     const val NO_PROGRESS = 0.0F
     const val FULL_PROGRESS = 1.0F
     const val INDETERMINATE_PROGRESS = -1.0F

--- a/android/ui/src/main/java/dev/keiji/deviceintegrity/ui/util/Base64Utils.kt
+++ b/android/ui/src/main/java/dev/keiji/deviceintegrity/ui/util/Base64Utils.kt
@@ -1,4 +1,4 @@
-package dev.keiji.deviceintegrity.ui.main.util
+package dev.keiji.deviceintegrity.ui.util
 
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.Base64.PaddingOption // Corrected import


### PR DESCRIPTION
Refactor: Move common UI components to the :ui module

I moved the following common classes and files from :ui:main to the :ui module to prepare for future module separation of playintegrity and keyattestation packages:

- `InfoItem.kt`
- `InfoItemFormatter.kt`
- `ProgressConstants.kt` (renamed from `PlayIntegrityProgressConstants.kt`)
- `Base64Utils.kt`

I also updated all references to these files to point to their new locations.