### PR TITLE
Fix(play_integrity): サーバー側の503エラーを修正

### DIFF
--- a/server/play_integrity/Dockerfile
+++ b/server/play_integrity/Dockerfile
@@ -10,8 +10,8 @@ COPY requirements.txt .
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the current directory contents into the container at /app
-COPY . .
+# Copy the current directory contents into the container at /app/play_integrity_pkg/
+COPY . /app/play_integrity_pkg/
 
 # Make port $PORT available to the world outside this container
 # Cloud Run sets this environment variable.
@@ -23,4 +23,4 @@ ENV PORT 8080
 ENV PLAY_INTEGRITY_PACKAGE_NAME="dev.keiji.deviceintegrity"
 
 # Run app.py when the container launches
-CMD exec gunicorn -b :$PORT play_integrity:app
+CMD exec gunicorn -b :$PORT play_integrity_pkg.play_integrity:app


### PR DESCRIPTION
- Gunicornの起動方法を変更し、play_integrityがパッケージとして正しくインポートされるようにDockerfileを修正しました。
- これにより、相対インポートに起因する `ImportError` が解決され、サーバーが正常に起動するようになります。