### PR TITLE
I've fixed the test errors and improved the import statements. Here's…

### DIFF
--- a/server/key_attestation/datastore_utils.py
+++ b/server/key_attestation/datastore_utils.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone, timedelta
+from google.api_core.exceptions import Conflict
 # from google.cloud import datastore # Avoid direct import if client is passed
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,6 @@ def store_key_attestation_session(datastore_client, session_id: str, nonce_encod
         if datastore_client.get(key):
             # Entity already exists, so this is a collision.
             # Raise a specific exception to be caught by the caller's retry loop.
-            from google.cloud.exceptions import Conflict
             raise Conflict(f'Session ID {session_id} already exists.')
         datastore_client.put(entity)
         logger.info(f'Stored key attestation session for session_id: {session_id}')
@@ -66,7 +66,6 @@ def store_agreement_key_attestation_session(datastore_client, session_id: str, n
 
     with datastore_client.transaction():
         if datastore_client.get(key):
-            from google.cloud.exceptions import Conflict
             raise Conflict(f'Session ID {session_id} already exists.')
         datastore_client.put(entity)
         logger.info(f'Stored agreement key attestation session for session_id: {session_id}')

--- a/server/key_attestation/key_attestation.py
+++ b/server/key_attestation/key_attestation.py
@@ -6,6 +6,7 @@ import uuid
 
 from flask import Flask, request, jsonify
 from google.cloud import datastore
+from google.api_core.exceptions import Conflict
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
@@ -84,7 +85,7 @@ def prepare_signature_attestation():
              logger.error(f'Datastore connection error during store_key_attestation_session on attempt {attempt+1}: {e}')
              if attempt >= 7:
                 return jsonify({'error': 'Failed to store session due to datastore connectivity'}), 503
-        except datastore.exceptions.Conflict:
+        except Conflict:
             logger.warning(f'Session ID {session_id} collision on attempt {attempt+1}. Retrying...')
             if attempt >= 7:
                 logger.error(f'Failed to generate unique session ID after 8 attempts.')
@@ -152,7 +153,7 @@ def prepare_agreement_attestation():
             logger.error(f'Datastore connection error during store_agreement_key_attestation_session on attempt {attempt+1}: {e}')
             if attempt >= 7:
                 return jsonify({'error': 'Failed to store session due to datastore connectivity'}), 503
-        except datastore.exceptions.Conflict:
+        except Conflict:
             logger.warning(f'Session ID {session_id} collision on attempt {attempt+1}. Retrying...')
             if attempt >= 7:
                 logger.error(f'Failed to generate unique session ID after 8 attempts.')

--- a/server/key_attestation/tests/test_datastore_utils.py
+++ b/server/key_attestation/tests/test_datastore_utils.py
@@ -26,7 +26,9 @@ class TestDatastoreUtils(unittest.TestCase):
         mock_key = MagicMock()
 
         mock_datastore_client.key.return_value = mock_key
-        mock_datastore_client.entity.return_value = mock_entity # Changed from Entity to entity
+        mock_datastore_client.entity.return_value = mock_entity
+        # Ensure that the transaction doesn't find an existing entity
+        mock_datastore_client.get.return_value = None
 
         session_id = "test_session_123"
         nonce_encoded = "test_nonce_encoded"


### PR DESCRIPTION
… a summary of the changes:

- I corrected the import for the `Conflict` exception to be from `google.api_core.exceptions` instead of `google.cloud.exceptions`.
- I updated `key_attestation.py` to catch the correct `Conflict` exception.
- I mocked the `datastore_client.get` call in `test_datastore_utils.py` to prevent `Conflict` exceptions during successful path tests.
- I moved the `Conflict` import to the top of the file in `datastore_utils.py`.