### PR TITLE
Refactor: Remove redundant `enabled` state from BottomNavigationItem

### DIFF
--- a/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
+++ b/android/ui/main/src/main/java/dev/keiji/deviceintegrity/ui/main/MainActivity.kt
@@ -146,7 +146,6 @@ fun DeviceIntegrityApp(
                             },
                             label = { Text(stringResource(id = screen.label)) },
                             selected = selected,
-                            enabled = isEnabled,
                             onClick = {
                                 navController.navigate(screen.route) {
                                     popUpTo(navController.graph.findStartDestination().id) {


### PR DESCRIPTION
The `enabled` state was already handled by the `selected` state, making it redundant. This change simplifies the BottomNavigationItem by removing the unnecessary `enabled` property.