### PR TITLE
feat: Fix Android build warnings and compilation errors

### DIFF
--- a/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/PlayIntegrityRepository.kt
+++ b/android/repository/contract/src/main/java/dev/keiji/deviceintegrity/repository/contract/PlayIntegrityRepository.kt
@@ -55,18 +55,6 @@ interface PlayIntegrityRepository {
 
     /**
      * Prepares a challenge (nonce) for classic integrity or Play Integrity API usage.
-     * @param sessionId A unique identifier for the session.
-     * @return [NonceResponse] containing the challenge.
-     * @throws ServerException if there is an issue communicating with the server or the server returns an error.
-     * @throws java.io.IOException for other network or I/O related issues.
-     */
-    @Throws(ServerException::class, java.io.IOException::class)
-    suspend fun getNonce(
-        sessionId: String
-    ): NonceResponse
-
-    /**
-     * Prepares a challenge (nonce) for classic integrity or Play Integrity API usage.
      * @return [NonceResponseV2] containing the challenge and session ID.
      * @throws ServerException if there is an issue communicating with the server or the server returns an error.
      * @throws java.io.IOException for other network or I/O related issues.

--- a/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityRepositoryImpl.kt
+++ b/android/repository/impl/src/main/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityRepositoryImpl.kt
@@ -75,19 +75,6 @@ class PlayIntegrityRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getNonce(sessionId: String): NonceResponse {
-        return try {
-            val request = CreateNonceRequest(sessionId = sessionId)
-            playIntegrityTokenVerifyApiClient.getNonce(request)
-        } catch (e: HttpException) {
-            throw ServerException(
-                errorCode = e.code(),
-                errorMessage = e.response()?.errorBody()?.string(),
-                cause = e
-            )
-        }
-    }
-
     override suspend fun getNonceV2(): NonceResponseV2 {
         return try {
             playIntegrityTokenVerifyApiClient.getNonceV2()

--- a/android/repository/impl/src/test/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityRepositoryImplTest.kt
+++ b/android/repository/impl/src/test/java/dev/keiji/deviceintegrity/repository/impl/PlayIntegrityRepositoryImplTest.kt
@@ -195,30 +195,4 @@ class PlayIntegrityRepositoryImplTest {
         Assert.assertEquals("Forbidden", exception.errorMessage)
     }
 
-    // --- getNonce Tests ---
-    @Test
-    fun `getNonce_success_should_return_NonceResponse`() = runTest {
-        val expectedResponse = NonceResponse("nonce_value", 12345L)
-        whenever(mockPlayIntegrityTokenVerifyApiClient.getNonce(any())).thenReturn(expectedResponse)
-
-        val result = repository.getNonce("sid")
-        Assert.assertEquals(expectedResponse, result)
-    }
-
-    @Test
-    fun `getNonce httpException should throw ServerException`() = runTest {
-        val httpException = HttpException(
-            Response.error<NonceResponse>(
-                500,
-                "Server Down".toResponseBody("text/plain".toMediaTypeOrNull())
-            )
-        )
-        whenever(mockPlayIntegrityTokenVerifyApiClient.getNonce(any())).thenThrow(httpException)
-
-        val exception = assertFailsWith<ServerException> {
-            repository.getNonce("sid")
-        }
-        Assert.assertEquals(500, exception.errorCode)
-        Assert.assertEquals("Server Down", exception.errorMessage)
-    }
 }

--- a/android/ui/main/build.gradle.kts
+++ b/android/ui/main/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.hilt.android.testing)
+    testImplementation(project(":ui:play-integrity"))
     kspTest(libs.hilt.compiler)
 
     androidTestImplementation(libs.androidx.junit)

--- a/android/ui/main/src/test/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModelTest.kt
+++ b/android/ui/main/src/test/java/dev/keiji/deviceintegrity/ui/main/playintegrity/ClassicPlayIntegrityViewModelTest.kt
@@ -14,6 +14,8 @@ import dev.keiji.deviceintegrity.provider.contract.GooglePlayDeveloperServiceInf
 import dev.keiji.deviceintegrity.repository.contract.ClassicPlayIntegrityTokenRepository
 import dev.keiji.deviceintegrity.repository.contract.PlayIntegrityRepository
 import dev.keiji.deviceintegrity.repository.contract.exception.ServerException
+import dev.keiji.deviceintegrity.ui.playintegrity.ClassicPlayIntegrityViewModel
+import dev.keiji.deviceintegrity.ui.playintegrity.ClassicPlayIntegrityUiState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -51,7 +53,6 @@ class ClassicPlayIntegrityViewModelTest {
     private lateinit var mockGooglePlayDeveloperServiceInfoProvider: GooglePlayDeveloperServiceInfoProvider
     private lateinit var mockAppInfoProvider: AppInfoProvider
 
-    // Dummy data
     private val dummyDeviceInfo = DeviceInfo("brand", "model", "device", "product", "manufacturer", "hardware", "board", "bootloader", "release", 30, "fingerprint", "patch")
     private val dummySecurityInfo = SecurityInfo(true, true, true, true)
     private val dummyGooglePlayDeveloperServiceInfo = GooglePlayDeveloperServiceInfo(123L, "1.2.3")
@@ -75,33 +76,21 @@ class ClassicPlayIntegrityViewModelTest {
         mockGooglePlayDeveloperServiceInfoProvider = mock()
         mockAppInfoProvider = mock()
 
-        // Mock provider methods to return dummy data
         whenever(mockGooglePlayDeveloperServiceInfoProvider.provide()).thenReturn(dummyGooglePlayDeveloperServiceInfo)
         whenever(mockDeviceInfoProvider.BRAND).thenReturn("TestBrand")
         whenever(mockDeviceInfoProvider.MODEL).thenReturn("TestModel")
         whenever(mockDeviceInfoProvider.DEVICE).thenReturn("TestDevice")
         whenever(mockDeviceInfoProvider.PRODUCT).thenReturn("TestDevice")
         whenever(mockDeviceInfoProvider.BOARD).thenReturn("TestDevice")
-        whenever(mockDeviceInfoProvider.BASE_OS).thenReturn("TestDevice")
         whenever(mockDeviceInfoProvider.BOOTLOADER).thenReturn("TestDevice")
-        whenever(mockDeviceInfoProvider.DISPLAY).thenReturn("TestDevice")
         whenever(mockDeviceInfoProvider.FINGERPRINT).thenReturn("TestDevice")
         whenever(mockDeviceInfoProvider.HARDWARE).thenReturn("TestDevice")
-        whenever(mockDeviceInfoProvider.HOST).thenReturn("TestDevice")
-        whenever(mockDeviceInfoProvider.ID).thenReturn("TestDevice")
         whenever(mockDeviceInfoProvider.MANUFACTURER).thenReturn("TestDevice")
         whenever(mockDeviceInfoProvider.SDK_INT).thenReturn(30)
         whenever(mockDeviceInfoProvider.SECURITY_PATCH).thenReturn("TestDevice")
-        whenever(mockDeviceInfoProvider.TAGS).thenReturn("TestDevice")
-        whenever(mockDeviceInfoProvider.TIME).thenReturn(0)
-        whenever(mockDeviceInfoProvider.TYPE).thenReturn("TestDevice")
-        whenever(mockDeviceInfoProvider.USER).thenReturn("TestDevice")
         whenever(mockDeviceInfoProvider.VERSION_RELEASE).thenReturn("TestDevice")
-        whenever(mockDeviceInfoProvider.VERSION_INCREMENTAL).thenReturn("TestDevice")
 
-        // ... mock other DeviceInfoProvider properties as needed
         whenever(mockDeviceSecurityStateProvider.isDeviceLockEnabled).thenReturn(true)
-        // ... mock other DeviceSecurityStateProvider properties
         whenever(mockAppInfoProvider.isDebugBuild).thenReturn(false)
 
 
@@ -128,11 +117,11 @@ class ClassicPlayIntegrityViewModelTest {
         whenever(mockPlayIntegrityRepository.getNonceV2()).thenReturn(expectedResponse)
 
         viewModel.fetchNonce()
-        testDispatcher.scheduler.advanceUntilIdle() // Execute coroutines
+        testDispatcher.scheduler.advanceUntilIdle()
 
         val uiState = viewModel.uiState.first()
         assertEquals(nonce, uiState.nonce)
-        assertEquals("Nonce fetched: $nonce", uiState.status)
+        assertEquals("Nonce fetched: ${nonce}", uiState.status)
         assertEquals(sessionId, uiState.currentSessionId)
         assertTrue(uiState.errorMessages.isEmpty())
     }
@@ -147,7 +136,7 @@ class ClassicPlayIntegrityViewModelTest {
 
         val uiState = viewModel.uiState.first()
         assertTrue(uiState.errorMessages.isNotEmpty())
-        assertEquals("Server error fetching nonce: Server error", uiState.status) // Updated
+        assertEquals("Server error fetching nonce: Server error", uiState.status)
         assertEquals("Server error: 500 - Server error", uiState.errorMessages.first())
     }
 
@@ -161,7 +150,7 @@ class ClassicPlayIntegrityViewModelTest {
 
         val uiState = viewModel.uiState.first()
         assertTrue(uiState.errorMessages.isNotEmpty())
-        assertEquals("Network error fetching nonce: Network error", uiState.status) // Updated
+        assertEquals("Network error fetching nonce: Network error", uiState.status)
         assertEquals("Network error", uiState.errorMessages.first())
     }
 
@@ -169,7 +158,7 @@ class ClassicPlayIntegrityViewModelTest {
     fun `fetchIntegrityToken success updates uiState with token`() = runTest {
         val nonce = "test-nonce"
         val token = "test-token"
-        viewModel.updateNonce(nonce) // Set nonce first
+        viewModel.updateNonce(nonce)
         whenever(mockClassicPlayIntegrityTokenRepository.getToken(nonce)).thenReturn(token)
 
         viewModel.fetchIntegrityToken()
@@ -238,7 +227,7 @@ class ClassicPlayIntegrityViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         val uiState = viewModel.uiState.first()
-        assertEquals("Server error verifying token: Forbidden by server", uiState.status) // Updated
+        assertEquals("Server error verifying token: Forbidden by server", uiState.status)
         assertTrue(uiState.errorMessages.isNotEmpty())
         assertEquals("Server error: 403 - Forbidden by server", uiState.errorMessages.first())
     }
@@ -270,15 +259,14 @@ class ClassicPlayIntegrityViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         val uiState = viewModel.uiState.first()
-        assertEquals("Network error verifying token: Network connection lost", uiState.status) // Updated
+        assertEquals("Network error verifying token: Network connection lost", uiState.status)
         assertTrue(uiState.errorMessages.isNotEmpty())
         assertEquals("Network connection lost", uiState.errorMessages.first())
     }
 
     @Test
     fun `init loads GooglePlayDeveloperServiceInfo and updates uiState`() = runTest {
-        // ViewModel is initialized in setUp, which should trigger the init block.
-        testDispatcher.scheduler.advanceUntilIdle() // Ensure coroutines in init complete
+        testDispatcher.scheduler.advanceUntilIdle()
 
         val uiState = viewModel.uiState.first()
         assertEquals(dummyGooglePlayDeveloperServiceInfo, uiState.googlePlayDeveloperServiceInfo)
@@ -305,10 +293,10 @@ class ClassicPlayIntegrityViewModelTest {
 
         whenever(mockPlayIntegrityRepository.verifyTokenClassic(
             eq(token),
-            eq(currentSessionId!!), // sessionId
-            any(), // deviceInfo
-            any(), // securityInfo
-            eq(dummyGooglePlayDeveloperServiceInfo) // Explicitly check this arg
+            eq(currentSessionId!!),
+            any(),
+            any(),
+            eq(dummyGooglePlayDeveloperServiceInfo)
         )).thenReturn(dummyServerVerificationPayload)
 
         viewModel.verifyToken()
@@ -316,6 +304,6 @@ class ClassicPlayIntegrityViewModelTest {
 
         val finalUiState = viewModel.uiState.first()
         assertEquals("Token verification complete.", finalUiState.status)
-        assertEquals(dummyServerVerificationPayload.playIntegrityResponse, finalUiState.serverVerificationPayload?.playIntegrityResponse)
+        assertEquals(dummyServerVerificationPayload, finalUiState.serverVerificationPayload)
     }
 }


### PR DESCRIPTION
This commit addresses two main issues that were causing the Android build to fail:

1.  **Deprecated `getNonce` function**: The `getNonce` function was deprecated and has been replaced with `getNonceV2`. The deprecated function and its associated tests have been removed.

2.  **Unresolved references in test files**: The `ClassicPlayIntegrityViewModelTest.kt` and `StandardPlayIntegrityViewModelTest.kt` files had unresolved references due to a missing module dependency. A `testImplementation` dependency on the `ui:play-integrity` module has been added to the `ui:main` module's `build.gradle.kts` file to resolve this issue. The tests have also been updated to align with the refactored view models.