### PR TITLE
chore: Update AGP version to 8.13.1

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.0-alpha03"
+agp = "8.13.1"
 datastoreVersion = "1.1.7"
 desugar_jdk_libs = "2.1.5"
 kotlin = "2.2.21"


### PR DESCRIPTION
Upgrades the Android Gradle Plugin (AGP) version from "8.13.0-alpha03" to "8.13.1" in the `libs.versions.toml` file.